### PR TITLE
fix(api): request GraphQL by network name

### DIFF
--- a/Mimir/Options/HeadlessStateServiceOption.cs
+++ b/Mimir/Options/HeadlessStateServiceOption.cs
@@ -1,8 +1,13 @@
 namespace Mimir.Options;
 
-public class HeadlessStateServiceOption
+public class HeadlessEndpoint
 {
-    public Uri HeadlessEndpoint { get; set; }
+    public Uri Endpoint { get; set; }
     public string? JwtIssuer { get; set; }
     public string? JwtSecretKey { get; set; }
+}
+
+public class HeadlessStateServiceOption
+{
+    public Dictionary<string, HeadlessEndpoint> Endpoints { get; set; }
 }

--- a/Mimir/appsettings.json
+++ b/Mimir/appsettings.json
@@ -10,6 +10,13 @@
     "ConnectionString": "mongodb://rootuser:rootpass@localhost:27017"
   },
   "StateService": {
-    "HeadlessEndpoint": "https://9c-main-full-state.nine-chronicles.com/graphql"
+    "Endpoints": {
+      "odin": {
+        "Endpoint": "https://9c-main-full-state.nine-chronicles.com/graphql"    
+      },
+      "heimdall": {
+        "Endpoint": "https://heimdall-full-state.nine-chronicles.com/graphql"
+      }
+    }
   }
 }


### PR DESCRIPTION
Currently, it only receives one GraphQL endpoint, which makes the network parameter irrelevant. I dynamically set the HttpClient via the HttpContextAccessor and fetch it per network. This change requires a bit more configuration in the appsettings.json.