### PR TITLE
Implement arena info, score state handlers in legacy account handler

### DIFF
--- a/Mimir.Worker/BlockPoller.cs
+++ b/Mimir.Worker/BlockPoller.cs
@@ -50,6 +50,7 @@ public class BlockPoller(
     {
         var operationResult = await headlessGqlClient.GetTransactionSigners.ExecuteAsync(
             processBlockIndex,
+            1,
             cancellationToken
         );
         if (operationResult.Data is null)

--- a/Mimir.Worker/Constants/CollectionNames.cs
+++ b/Mimir.Worker/Constants/CollectionNames.cs
@@ -15,6 +15,7 @@ namespace Mimir.Worker.Constants
             CollectionMappings.Add(typeof(QuestListState), "quest_list");
             CollectionMappings.Add(typeof(WorldInformationState), "world_information");
             CollectionMappings.Add(typeof(SheetState), "table_sheet");
+            CollectionMappings.Add(typeof(ArenaScoreState), "arena_score");
         }
     }
 }

--- a/Mimir.Worker/Constants/CollectionNames.cs
+++ b/Mimir.Worker/Constants/CollectionNames.cs
@@ -16,6 +16,7 @@ namespace Mimir.Worker.Constants
             CollectionMappings.Add(typeof(WorldInformationState), "world_information");
             CollectionMappings.Add(typeof(SheetState), "table_sheet");
             CollectionMappings.Add(typeof(ArenaScoreState), "arena_score");
+            CollectionMappings.Add(typeof(ArenaInformationState), "arena_information");
         }
     }
 }

--- a/Mimir.Worker/Handler/AvatarStateHandler.cs
+++ b/Mimir.Worker/Handler/AvatarStateHandler.cs
@@ -8,19 +8,10 @@ namespace Mimir.Worker.Handler;
 
 public class AvatarStateHandler : IStateHandler<StateData>
 {
-    public StateData ConvertToStateData(Address address, IValue rawState)
+    public StateData ConvertToStateData(StateDiffContext context)
     {
-        var avatarState = ConvertToState(rawState);
-        return new StateData(address, avatarState);
-    }
-
-    public StateData ConvertToStateData(Address address, string rawState)
-    {
-        Codec Codec = new();
-        var state = Codec.Decode(Convert.FromHexString(rawState));
-        var avatarState = ConvertToState(state);
-
-        return new StateData(address, avatarState);
+        var avatarState = ConvertToState(context.RawState);
+        return new StateData(context.Address, avatarState);
     }
 
     private AvatarState ConvertToState(IValue state)

--- a/Mimir.Worker/Handler/IStateHandler.cs
+++ b/Mimir.Worker/Handler/IStateHandler.cs
@@ -6,6 +6,5 @@ namespace Mimir.Worker.Handler;
 
 public interface IStateHandler<T> where T : StateData
 {
-    T ConvertToStateData(Address address, string rawState);
-    T ConvertToStateData(Address address, IValue rawState);
+    T ConvertToStateData(StateDiffContext context);
 }

--- a/Mimir.Worker/Handler/InventoryStateHandler.cs
+++ b/Mimir.Worker/Handler/InventoryStateHandler.cs
@@ -8,19 +8,10 @@ namespace Mimir.Worker.Handler;
 
 public class InventoryStateHandler : IStateHandler<StateData>
 {
-    public StateData ConvertToStateData(Address address, IValue rawState)
+    public StateData ConvertToStateData(StateDiffContext context)
     {
-        var inventoryState = ConvertToState(rawState);
-        return new StateData(address, new InventoryState(address, inventoryState));
-    }
-
-    public StateData ConvertToStateData(Address address, string rawState)
-    {
-        Codec Codec = new();
-        var state = Codec.Decode(Convert.FromHexString(rawState));
-        var inventoryState = ConvertToState(state);
-
-        return new StateData(address, new InventoryState(address, inventoryState));
+        var inventoryState = ConvertToState(context.RawState);
+        return new StateData(context.Address, new InventoryState(context.Address, inventoryState));
     }
 
     private Inventory ConvertToState(IValue state)

--- a/Mimir.Worker/Handler/LegacyAccountHandler.cs
+++ b/Mimir.Worker/Handler/LegacyAccountHandler.cs
@@ -86,6 +86,7 @@ public class LegacyAccountHandler : IStateHandler<StateData>
             if (Regex.IsMatch(actionType, "^battle_arena[0-9]*$"))
             {
                 var avatarAddress = new Address(((Dictionary)actionValues)["maa"]);
+                var enemyAvatarAddress = new Address(((Dictionary)actionValues)["eaa"]);
 
                 for (int championshipId = 0; championshipId <= 50; championshipId++)
                 {
@@ -97,6 +98,22 @@ public class LegacyAccountHandler : IStateHandler<StateData>
                             .Add(
                                 ArenaInformation.DeriveAddress(
                                     avatarAddress,
+                                    championshipId,
+                                    roundId
+                                )
+                            );
+                        addresses["ArenaScoreAddresses"]
+                            .Add(
+                                ArenaScore.DeriveAddress(
+                                    enemyAvatarAddress,
+                                    championshipId,
+                                    roundId
+                                )
+                            );
+                        addresses["ArenaInfoAddresses"]
+                            .Add(
+                                ArenaInformation.DeriveAddress(
+                                    enemyAvatarAddress,
                                     championshipId,
                                     roundId
                                 )
@@ -117,7 +134,10 @@ public class LegacyAccountHandler : IStateHandler<StateData>
         }
         else
         {
-            throw new ArgumentException($"Invalid state type. Expected List. Actual: {state.GetType().Name}", nameof(state));
+            throw new ArgumentException(
+                $"Invalid state type. Expected List. Actual: {state.GetType().Name}",
+                nameof(state)
+            );
         }
     }
 
@@ -129,7 +149,10 @@ public class LegacyAccountHandler : IStateHandler<StateData>
         }
         else
         {
-            throw new ArgumentException($"Invalid state type. Expected List.  Actual: {state.GetType().Name}", nameof(state));
+            throw new ArgumentException(
+                $"Invalid state type. Expected List.  Actual: {state.GetType().Name}",
+                nameof(state)
+            );
         }
     }
 

--- a/Mimir.Worker/Handler/LegacyAccountHandler.cs
+++ b/Mimir.Worker/Handler/LegacyAccountHandler.cs
@@ -117,7 +117,7 @@ public class LegacyAccountHandler : IStateHandler<StateData>
         }
         else
         {
-            throw new ArgumentException("Invalid state type. Expected List.", nameof(state));
+            throw new ArgumentException($"Invalid state type. Expected List. Actual: {state.GetType().Name}", nameof(state));
         }
     }
 
@@ -129,7 +129,7 @@ public class LegacyAccountHandler : IStateHandler<StateData>
         }
         else
         {
-            throw new ArgumentException("Invalid state type. Expected List.", nameof(state));
+            throw new ArgumentException($"Invalid state type. Expected List.  Actual: {state.GetType().Name}", nameof(state));
         }
     }
 

--- a/Mimir.Worker/Handler/QuestListStateHandler.cs
+++ b/Mimir.Worker/Handler/QuestListStateHandler.cs
@@ -8,19 +8,10 @@ namespace Mimir.Worker.Handler;
 
 public class QuestListStateHandler : IStateHandler<StateData>
 {
-    public StateData ConvertToStateData(Address address, IValue rawState)
+    public StateData ConvertToStateData(StateDiffContext context)
     {
-        var questList = ConvertToState(rawState);
-        return new StateData(address, new QuestListState(address, questList));
-    }
-
-    public StateData ConvertToStateData(Address address, string rawState)
-    {
-        Codec Codec = new();
-        var state = Codec.Decode(Convert.FromHexString(rawState));
-        var questList = ConvertToState(state);
-
-        return new StateData(address, new QuestListState(address, questList));
+        var questList = ConvertToState(context.RawState);
+        return new StateData(context.Address, new QuestListState(context.Address, questList));
     }
 
     private QuestList ConvertToState(IValue state)

--- a/Mimir.Worker/Handler/StateDiffContext.cs
+++ b/Mimir.Worker/Handler/StateDiffContext.cs
@@ -1,0 +1,12 @@
+using Bencodex.Types;
+using HeadlessGQL;
+using Libplanet.Crypto;
+
+namespace Mimir.Worker.Handler;
+
+public class StateDiffContext
+{
+    public Address Address { get; set; }
+    public IValue RawState { get; set; }
+    public IEnumerable<IGetTransactionSigners_Transaction_NcTransactions>? Transactions { get; set; } = null;
+}

--- a/Mimir.Worker/Handler/WorldInformationStateHandler.cs
+++ b/Mimir.Worker/Handler/WorldInformationStateHandler.cs
@@ -8,19 +8,13 @@ namespace Mimir.Worker.Handler;
 
 public class WorldInformationStateHandler : IStateHandler<StateData>
 {
-    public StateData ConvertToStateData(Address address, IValue rawState)
+    public StateData ConvertToStateData(StateDiffContext context)
     {
-        var worldInformation = ConvertToState(rawState);
-        return new StateData(address, new WorldInformationState(address, worldInformation));
-    }
-
-    public StateData ConvertToStateData(Address address, string rawState)
-    {
-        Codec Codec = new();
-        var state = Codec.Decode(Convert.FromHexString(rawState));
-        var worldInformation = ConvertToState(state);
-
-        return new StateData(address, new WorldInformationState(address, worldInformation));
+        var worldInformation = ConvertToState(context.RawState);
+        return new StateData(
+            context.Address,
+            new WorldInformationState(context.Address, worldInformation)
+        );
     }
 
     private WorldInformation ConvertToState(IValue state)

--- a/Mimir.Worker/Models/State/ArenaInformationState.cs
+++ b/Mimir.Worker/Models/State/ArenaInformationState.cs
@@ -1,0 +1,16 @@
+using Libplanet.Crypto;
+using Nekoyume.Model.Arena;
+using Nekoyume.Model.State;
+
+namespace Mimir.Worker.Models;
+
+public class ArenaInformationState : State
+{
+    public ArenaInformation ArenaInformation;
+
+    public ArenaInformationState(Address address, ArenaInformation arenaInformation)
+        : base(address)
+    {
+        ArenaInformation = arenaInformation;
+    }
+}

--- a/Mimir.Worker/Models/State/ArenaScoreState.cs
+++ b/Mimir.Worker/Models/State/ArenaScoreState.cs
@@ -1,0 +1,16 @@
+using Libplanet.Crypto;
+using Nekoyume.Model.Arena;
+using Nekoyume.Model.State;
+
+namespace Mimir.Worker.Models;
+
+public class ArenaScoreState : State
+{
+    public ArenaScore ArenaScore;
+
+    public ArenaScoreState(Address address, ArenaScore arenaScore)
+        : base(address)
+    {
+        ArenaScore = arenaScore;
+    }
+}

--- a/Mimir.Worker/Queries.graphql
+++ b/Mimir.Worker/Queries.graphql
@@ -28,12 +28,9 @@ query GetPatchTableTransactions($blockIndex: Long!) {
 
 query GetTransactionSigners($blockIndex: Long!, $limit: Long!) {
     transaction {
-        ncTransactions(startingBlockIndex: $blockIndex, limit: $limit, actionType: "^[a-zA-Z0-9]*$") {
+        ncTransactions(startingBlockIndex: $blockIndex, limit: $limit, actionType: "^.*$") {
             signer
             serializedPayload
-            actions {
-                raw
-            }
         }
     }
 }

--- a/Mimir.Worker/Queries.graphql
+++ b/Mimir.Worker/Queries.graphql
@@ -40,6 +40,9 @@ query GetTransactionSigners($blockIndex: Long!, $limit: Long!) {
             id
             signer
             serializedPayload
+            actions {
+                raw
+            }
         }
     }
 }

--- a/Mimir.Worker/Queries.graphql
+++ b/Mimir.Worker/Queries.graphql
@@ -6,6 +6,14 @@ query GetTip {
     }
 }
 
+query GetTransactionResults($transactionIds: [TxId]!) {
+  transaction {
+    transactionResults(txIds: $transactionIds) {
+      txStatus
+    }
+  }
+}
+
 query GetState($accountAddress: Address! $address: Address!) {
     state(accountAddress: $accountAddress, address: $address)
 }
@@ -29,6 +37,7 @@ query GetPatchTableTransactions($blockIndex: Long!) {
 query GetTransactionSigners($blockIndex: Long!, $limit: Long!) {
     transaction {
         ncTransactions(startingBlockIndex: $blockIndex, limit: $limit, actionType: "^.*$") {
+            id
             signer
             serializedPayload
         }

--- a/Mimir.Worker/Queries.graphql
+++ b/Mimir.Worker/Queries.graphql
@@ -26,10 +26,14 @@ query GetPatchTableTransactions($blockIndex: Long!) {
     }
 }
 
-query GetTransactionSigners($blockIndex: Long!) {
+query GetTransactionSigners($blockIndex: Long!, $limit: Long!) {
     transaction {
-        ncTransactions(startingBlockIndex: $blockIndex, limit: 1, actionType: "^[a-zA-Z0-9]*$") {
+        ncTransactions(startingBlockIndex: $blockIndex, limit: $limit, actionType: "^[a-zA-Z0-9]*$") {
             signer
+            serializedPayload
+            actions {
+                raw
+            }
         }
     }
 }

--- a/Mimir.Worker/Scrapper/DiffScrapper.cs
+++ b/Mimir.Worker/Scrapper/DiffScrapper.cs
@@ -87,8 +87,8 @@ public class DiffScrapper
         }
 
         return operationResult
-            .Data.Transaction.NcTransactions.Where(tx => tx != null)
-            .Cast<IGetTransactionSigners_Transaction_NcTransactions>()
+            .Data.Transaction.NcTransactions
+            .OfType<IGetTransactionSigners_Transaction_NcTransactions>()
             .ToList();
     }
 

--- a/Mimir.Worker/Scrapper/DiffScrapper.cs
+++ b/Mimir.Worker/Scrapper/DiffScrapper.cs
@@ -1,5 +1,7 @@
+using Bencodex;
 using HeadlessGQL;
 using Libplanet.Crypto;
+using Libplanet.Types.Tx;
 using Mimir.Worker.Constants;
 using Mimir.Worker.Handler;
 using Mimir.Worker.Models;
@@ -12,6 +14,8 @@ public class DiffScrapper
 {
     private readonly HeadlessGQLClient _headlessGqlClient;
     private readonly DiffMongoDbService _store;
+
+    private readonly Codec Codec = new();
 
     public DiffScrapper(HeadlessGQLClient headlessGqlClient, DiffMongoDbService store)
     {
@@ -34,6 +38,10 @@ public class DiffScrapper
                 currentBaseIndex,
                 currentTargetIndex
             );
+            var txs = await GetTransactions(
+                currentBaseIndex,
+                currentTargetIndex - currentBaseIndex
+            );
 
             if (diffResult.Data?.Diffs != null)
             {
@@ -42,11 +50,11 @@ public class DiffScrapper
                     switch (diff)
                     {
                         case IGetDiffs_Diffs_RootStateDiff rootDiff:
-                            ProcessRootStateDiff(rootDiff);
+                            ProcessRootStateDiff(rootDiff, txs);
                             break;
 
                         case IGetDiffs_Diffs_StateDiff stateDiff:
-                            ProcessStateDiff(stateDiff);
+                            ProcessStateDiff(stateDiff, txs);
                             break;
                     }
                 }
@@ -57,7 +65,37 @@ public class DiffScrapper
         }
     }
 
-    private async void ProcessRootStateDiff(IGetDiffs_Diffs_RootStateDiff rootDiff)
+    private async Task<
+        IEnumerable<IGetTransactionSigners_Transaction_NcTransactions>
+    > GetTransactions(long processBlockIndex, long limit)
+    {
+        var operationResult = await _headlessGqlClient.GetTransactionSigners.ExecuteAsync(
+            processBlockIndex,
+            limit
+        );
+
+        if (
+            operationResult.Data?.Transaction?.NcTransactions == null
+            || !operationResult.Data.Transaction.NcTransactions.Any()
+        )
+        {
+            Serilog.Log.Error(
+                "No transactions found or null data. Process Block Index: {ProcessBlockIndex}",
+                processBlockIndex
+            );
+            return Enumerable.Empty<IGetTransactionSigners_Transaction_NcTransactions>();
+        }
+
+        return operationResult
+            .Data.Transaction.NcTransactions.Where(tx => tx != null)
+            .Cast<IGetTransactionSigners_Transaction_NcTransactions>()
+            .ToList();
+    }
+
+    private async void ProcessRootStateDiff(
+        IGetDiffs_Diffs_RootStateDiff rootDiff,
+        IEnumerable<IGetTransactionSigners_Transaction_NcTransactions> txs
+    )
     {
         var accountAddress = new Address(rootDiff.Path);
         if (AddressHandlerMappings.HandlerMappings.TryGetValue(accountAddress, out var handler))
@@ -69,8 +107,14 @@ public class DiffScrapper
                     try
                     {
                         var stateData = handler.ConvertToStateData(
-                            new Address(subDiff.Path),
-                            subDiff.ChangedState
+                            new()
+                            {
+                                Address = new Address(subDiff.Path),
+                                RawState = Codec.Decode(
+                                    Convert.FromHexString(subDiff.ChangedState)
+                                ),
+                                Transactions = txs
+                            }
                         );
 
                         if (
@@ -96,5 +140,8 @@ public class DiffScrapper
         }
     }
 
-    private void ProcessStateDiff(IGetDiffs_Diffs_StateDiff stateDiff) { }
+    private void ProcessStateDiff(
+        IGetDiffs_Diffs_StateDiff stateDiff,
+        IEnumerable<IGetTransactionSigners_Transaction_NcTransactions> txs
+    ) { }
 }

--- a/Mimir.Worker/SnapshotInitializer.cs
+++ b/Mimir.Worker/SnapshotInitializer.cs
@@ -90,7 +90,6 @@ public class SnapshotInitializer
 
         long addressCount = 0;
         string? currentAddress = null;
-        // var txs = GetTransactions();
 
         foreach ((KeyBytes keyBytes, IValue value) in accountTrie.IterateValues())
         {
@@ -108,7 +107,6 @@ public class SnapshotInitializer
                     {
                         Address = new Address(currentAddress),
                         RawState = value,
-                        // Transactions = txs
                     }
                 );
                 if (
@@ -135,16 +133,4 @@ public class SnapshotInitializer
         store.Dispose();
         stateStore.Dispose();
     }
-
-    // private async Task GetTransactions(BlockChain chain, long blockIndex)
-    // {
-    //     var count = (int)Math.Min(1, chain.Tip.Index - blockIndex + 1);
-    //     var blocks = Enumerable.Range(0, count)
-    //         .ToList()
-    //         .AsParallel()
-    //         .Select(offset => chain[blockIndex + offset])
-    //         .OrderBy(block => block.Index);
-
-    //     var transactions = blocks.SelectMany(block => block.Transactions);
-    // }
 }

--- a/Mimir.Worker/SnapshotInitializer.cs
+++ b/Mimir.Worker/SnapshotInitializer.cs
@@ -90,6 +90,7 @@ public class SnapshotInitializer
 
         long addressCount = 0;
         string? currentAddress = null;
+        // var txs = GetTransactions();
 
         foreach ((KeyBytes keyBytes, IValue value) in accountTrie.IterateValues())
         {
@@ -102,7 +103,14 @@ public class SnapshotInitializer
 
             if (currentAddress is string hex)
             {
-                var stateData = handler.ConvertToStateData(new Address(currentAddress), value);
+                var stateData = handler.ConvertToStateData(
+                    new()
+                    {
+                        Address = new Address(currentAddress),
+                        RawState = value,
+                        // Transactions = txs
+                    }
+                );
                 if (
                     CollectionNames.CollectionMappings.TryGetValue(
                         stateData.State.GetType(),
@@ -127,4 +135,16 @@ public class SnapshotInitializer
         store.Dispose();
         stateStore.Dispose();
     }
+
+    // private async Task GetTransactions(BlockChain chain, long blockIndex)
+    // {
+    //     var count = (int)Math.Min(1, chain.Tip.Index - blockIndex + 1);
+    //     var blocks = Enumerable.Range(0, count)
+    //         .ToList()
+    //         .AsParallel()
+    //         .Select(offset => chain[blockIndex + offset])
+    //         .OrderBy(block => block.Index);
+
+    //     var transactions = blocks.SelectMany(block => block.Transactions);
+    // }
 }


### PR DESCRIPTION
Close https://github.com/planetarium/mimir/issues/87

The arena handlers are quite messy and not well-optimized 😭.
I need to think about how to make the code more efficient, but for now, it works. 👍 

First, it retrieves all the transactions existing in the block and checks their actions.
If there's a `battle_arena` action, it collects the avatar addresses from the action values.
Then, it pre-generates a large number of derived addresses and matches them accordingly.