### PR TITLE
feat: introduce "agent" query

### DIFF
--- a/Mimir/GraphQL/Objects/AgentObject.cs
+++ b/Mimir/GraphQL/Objects/AgentObject.cs
@@ -1,0 +1,8 @@
+using Libplanet.Crypto;
+
+namespace Mimir.GraphQL.Objects;
+
+public class AgentObject(Address address)
+{
+    public Address Address { get; set; } = address;
+}

--- a/Mimir/GraphQL/Objects/AvatarObject.cs
+++ b/Mimir/GraphQL/Objects/AvatarObject.cs
@@ -2,7 +2,9 @@ using Libplanet.Crypto;
 
 namespace Mimir.GraphQL.Objects;
 
-public class AvatarObject(Address address)
+public class AvatarObject(Address address, Address? agentAddress = null, int? index = null)
 {
     public Address Address { get; set; } = address;
+    public Address? AgentAddress { get; set; } = agentAddress;
+    public int? Index { get; set; } = index;
 }

--- a/Mimir/GraphQL/Objects/AvatarObject.cs
+++ b/Mimir/GraphQL/Objects/AvatarObject.cs
@@ -1,5 +1,8 @@
+using Libplanet.Crypto;
+
 namespace Mimir.GraphQL.Objects;
 
-public class AvatarObject
+public class AvatarObject(Address address)
 {
+    public Address Address { get; set; } = address;
 }

--- a/Mimir/GraphQL/Types/AgentType.cs
+++ b/Mimir/GraphQL/Types/AgentType.cs
@@ -1,0 +1,47 @@
+using Lib9c.GraphQL.Types;
+using Libplanet.Crypto;
+using Mimir.GraphQL.Objects;
+using Nekoyume;
+
+namespace Mimir.GraphQL.Types;
+
+public class AgentType : ObjectType<AgentObject>
+{
+    protected override void Configure(IObjectTypeDescriptor<AgentObject> descriptor)
+    {
+        descriptor
+            .Field(f => f.Address)
+            .Type<NonNullType<AddressType>>();
+        descriptor
+            .Field("avatar")
+            .Argument("index", a => a.Type<NonNullType<IntType>>())
+            .Type<AvatarType>()
+            .Resolve(context =>
+            {
+                var agentAddress = context.Parent<AgentObject>().Address;
+                var index = context.ArgumentValue<int>("index");
+                Address avatarAddress;
+                try
+                {
+                    avatarAddress = Addresses.GetAvatarAddress(agentAddress, index);
+                }
+                catch (ArgumentOutOfRangeException)
+                {
+                    return null;
+                }
+
+                return new AvatarObject(avatarAddress);
+            });
+        descriptor
+            .Field("avatars")
+            .Type<NonNullType<ListType<NonNullType<AvatarType>>>>()
+            .Resolve(context =>
+            {
+                var agentAddress = context.Parent<AgentObject>().Address;
+                return Enumerable.Range(0, GameConfig.SlotCount)
+                    .Select(i => Addresses.GetAvatarAddress(agentAddress, i))
+                    .Select(avatarAddress => new AvatarObject(avatarAddress))
+                    .ToList();
+            });
+    }
+}

--- a/Mimir/GraphQL/Types/AgentType.cs
+++ b/Mimir/GraphQL/Types/AgentType.cs
@@ -30,7 +30,7 @@ public class AgentType : ObjectType<AgentObject>
                     return null;
                 }
 
-                return new AvatarObject(avatarAddress);
+                return new AvatarObject(avatarAddress, agentAddress, index);
             });
         descriptor
             .Field("avatars")
@@ -39,8 +39,11 @@ public class AgentType : ObjectType<AgentObject>
             {
                 var agentAddress = context.Parent<AgentObject>().Address;
                 return Enumerable.Range(0, GameConfig.SlotCount)
-                    .Select(i => Addresses.GetAvatarAddress(agentAddress, i))
-                    .Select(avatarAddress => new AvatarObject(avatarAddress))
+                    .Select(i => (index: i, avatarAddress: Addresses.GetAvatarAddress(agentAddress, i)))
+                    .Select(tuple => new AvatarObject(
+                        tuple.avatarAddress,
+                        agentAddress,
+                        tuple.index))
                     .ToList();
             });
     }

--- a/Mimir/GraphQL/Types/AvatarType.cs
+++ b/Mimir/GraphQL/Types/AvatarType.cs
@@ -17,18 +17,29 @@ public class AvatarType : ObjectType<AvatarObject>
             .Field(f => f.Address)
             .Type<NonNullType<AddressType>>();
         descriptor
-            .Field("agentAddress")
+            .Field(f => f.AgentAddress)
             .Type<AddressType>()
             .Resolve(context =>
             {
+                var agentAddress = context.Parent<AvatarObject>().AgentAddress;
+                if (agentAddress.HasValue)
+                {
+                    return agentAddress;
+                }
+
                 var avatar = GetAvatar(context);
                 if (avatar is null)
                 {
                     return null;
                 }
 
-                return new Address(avatar.AgentAddress);
+                agentAddress = new Address(avatar.AgentAddress);
+                context.Parent<AvatarObject>().AgentAddress = agentAddress;
+                return agentAddress;
             });
+        descriptor
+            .Field(f => f.Index)
+            .Type<IntType>();
         descriptor
             .Field("name")
             .Type<StringType>()

--- a/Mimir/GraphQL/Types/AvatarType.cs
+++ b/Mimir/GraphQL/Types/AvatarType.cs
@@ -14,6 +14,9 @@ public class AvatarType : ObjectType<AvatarObject>
     protected override void Configure(IObjectTypeDescriptor<AvatarObject> descriptor)
     {
         descriptor
+            .Field(f => f.Address)
+            .Type<NonNullType<AddressType>>();
+        descriptor
             .Field("agentAddress")
             .Type<AddressType>()
             .Resolve(context =>
@@ -65,15 +68,8 @@ public class AvatarType : ObjectType<AvatarObject>
             return null;
         }
 
-        var avatarAddress = context.ScopedContextData.TryGetValue("avatarAddress", out var aa)
-            ? (Address?)aa
-            : null;
-        if (avatarAddress is null)
-        {
-            return null;
-        }
-
-        return (avatarRepo, planetName.Value, avatarAddress.Value);
+        var avatarAddress = context.Parent<AvatarObject>().Address;
+        return (avatarRepo, planetName.Value, avatarAddress);
     }
 
     private static Avatar? GetAvatar(IResolverContext context)

--- a/Mimir/GraphQL/Types/QueryType.cs
+++ b/Mimir/GraphQL/Types/QueryType.cs
@@ -11,6 +11,18 @@ public class QueryType : ObjectType<Query>
     protected override void Configure(IObjectTypeDescriptor<Query> descriptor)
     {
         descriptor
+            .Field("agent")
+            .Argument("planetName", a => a.Type<NonNullType<PlanetNameEnumType>>())
+            .Argument("address", a => a.Type<NonNullType<AddressType>>())
+            .Type<AgentType>()
+            .Resolve(context =>
+            {
+                context.ScopedContextData = context.ScopedContextData
+                    .Add("planetName", context.ArgumentValue<PlanetName>("planetName"));
+                return new AgentObject(context.ArgumentValue<Address>("address"));
+            });
+
+        descriptor
             .Field("avatar")
             .Argument("planetName", a => a.Type<NonNullType<PlanetNameEnumType>>())
             .Argument("address", a => a.Type<NonNullType<AddressType>>())

--- a/Mimir/GraphQL/Types/QueryType.cs
+++ b/Mimir/GraphQL/Types/QueryType.cs
@@ -18,9 +18,8 @@ public class QueryType : ObjectType<Query>
             .Resolve(context =>
             {
                 context.ScopedContextData = context.ScopedContextData
-                    .Add("planetName", context.ArgumentValue<PlanetName>("planetName"))
-                    .Add("avatarAddress", context.ArgumentValue<Address>("address"));
-                return new AvatarObject();
+                    .Add("planetName", context.ArgumentValue<PlanetName>("planetName"));
+                return new AvatarObject(context.ArgumentValue<Address>("address"));
             });
     }
 }


### PR DESCRIPTION
- Introduce "agent" query.
- Add "Address" property to "AvatarObject".

# Example

```graphql
query (
    $planetName: PlanetName! = ODIN,
    $agentAddress: Address! = "0xCEB5910a777394a809516D34fEc6f964461413EF") {
    agent(planetName: $planetName, address: $agentAddress)
    {
        avatar(index: 1)
        {
            name
        }
        avatars
        {
            address
            name
        }
    }
}
```
```json
{
  "data": {
    "agent": {
      "avatar": {
        "name": "Vall7777"
      },
      "avatars": [
        {
          "address": "0xf6BC3f19842AE7d0CD96AA50F7B1bb52735FfE1c",
          "name": "VaaV"
        },
        {
          "address": "0x4D5E42553f35c711f4f07757cf73A97a2F69E69c",
          "name": "Vall7777"
        },
        {
          "address": "0xb5981087B2eEDD93262e0B09146c2a4aB9AA9c3B",
          "name": null
        }
      ]
    }
}
```