### PR TITLE
Ignore Serialized values

### DIFF
--- a/Mimir.Worker/DiffBlockPoller.cs
+++ b/Mimir.Worker/DiffBlockPoller.cs
@@ -33,20 +33,7 @@ public class DiffBlockPoller
         while (!stoppingToken.IsCancellationRequested)
         {
             var currentBlockIndex = await _stateService.GetLatestIndex();
-            long syncedBlockIndex;
-            try
-            {
-                syncedBlockIndex = await GetSyncedBlockIndex(currentBlockIndex);
-            }
-            catch (System.InvalidOperationException)
-            {
-                _logger.LogInformation(
-                    $"Metadata collection not founded, set block index to {currentBlockIndex} - 1"
-                );
-                syncedBlockIndex = currentBlockIndex - 1;
-                await _store.UpdateLatestBlockIndex(currentBlockIndex - 1);
-            }
-
+            var syncedBlockIndex = await GetSyncedBlockIndex(currentBlockIndex);
             var processBlockIndex = syncedBlockIndex + 1;
 
             _logger.LogInformation(
@@ -76,9 +63,10 @@ public class DiffBlockPoller
         }
         catch (System.InvalidOperationException)
         {
-            _logger.LogError(
-                $"Failed to get block indexes from db, Set `syncedBlockIndex` {currentBlockIndex} - 1"
+            _logger.LogInformation(
+                $"Metadata collection not founded, set block index to {currentBlockIndex} - 1"
             );
+            await _store.UpdateLatestBlockIndex(currentBlockIndex - 1);
             return currentBlockIndex - 1;
         }
     }

--- a/Mimir.Worker/Models/State/WorldInfomationState.cs
+++ b/Mimir.Worker/Models/State/WorldInfomationState.cs
@@ -1,3 +1,5 @@
+using Bencodex;
+using Bencodex.Types;
 using Libplanet.Crypto;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
@@ -8,9 +10,15 @@ public class WorldInformationState : State
 {
     public WorldInformation WorldInformation;
 
+    public IDictionary<int, WorldInformation.World> worlds;
+
     public WorldInformationState(Address address, WorldInformation worldInformation)
         : base(address)
     {
         WorldInformation = worldInformation;
+        worlds = ((Dictionary)worldInformation.Serialize()).ToDictionary(
+            (KeyValuePair<IKey, IValue> kv) => kv.Key.ToInteger(),
+            (KeyValuePair<IKey, IValue> kv) => new WorldInformation.World((Dictionary)kv.Value)
+        );
     }
 }

--- a/Mimir.Worker/Models/State/WorldInfomationState.cs
+++ b/Mimir.Worker/Models/State/WorldInfomationState.cs
@@ -8,15 +8,12 @@ namespace Mimir.Worker.Models;
 
 public class WorldInformationState : State
 {
-    public WorldInformation WorldInformation;
-
-    public IDictionary<int, WorldInformation.World> worlds;
+    public IDictionary<int, WorldInformation.World> WorldInformation;
 
     public WorldInformationState(Address address, WorldInformation worldInformation)
         : base(address)
     {
-        WorldInformation = worldInformation;
-        worlds = ((Dictionary)worldInformation.Serialize()).ToDictionary(
+        WorldInformation = ((Dictionary)worldInformation.Serialize()).ToDictionary(
             (KeyValuePair<IKey, IValue> kv) => kv.Key.ToInteger(),
             (KeyValuePair<IKey, IValue> kv) => new WorldInformation.World((Dictionary)kv.Value)
         );


### PR DESCRIPTION
<img width="838" alt="image" src="https://github.com/planetarium/mimir/assets/30599098/1772e304-5d03-41aa-8b6e-a5bbc4914018">

Some state classes implemented `GetObjectData` method

```
https://www.newtonsoft.com/json/help/html/SerializationGuide.htm

ISerializable
Types that implement [ISerializable](http://msdn2.microsoft.com/en-us/library/wf4375ks) and are marked with [SerializableAttribute](http://msdn2.microsoft.com/en-us/library/bcfsa90a) are serialized as JSON objects. When serializing, only the values returned from ISerializable.GetObjectData are used; members on the type are ignored. When deserializing, the constructor with a SerializationInfo and StreamingContext is called, passing the JSON object's values.
```

Unfortunately, we don't want to `serialized` value So I added ignore option
