### PR TITLE
ci(gh-actions): push docker image on only main branch

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -2,6 +2,8 @@ name: Build Docker Images
 
 on:
   push:
+    branches:
+      - main
 
 jobs:
   buildx:

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,7 +40,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v5
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/arm64,linux/amd64
           tags: ${{ matrix.docker.repo }}:git-${{ github.sha }}
           file: ${{ matrix.docker.dockerfile }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,6 +32,7 @@ jobs:
           platforms: linux/arm/v8,linux/amd64
       -
         name: Login to Docker Hub
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   buildx:


### PR DESCRIPTION
Looking at the other PRs, I realize that the main branch is deploying Docker images even though it's a branch, so I raise this PR to correct that.