### PR TITLE
ci(gh-actions): run dotnet-test in CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,25 @@
+name: Test Projects
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: 'Test (${{ matrix.project.test }})'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project:
+          - test: Mimir.Worker.Tests
+            codegen: Mimir.Worker
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - run: dotnet tool restore
+      - run: dotnet graphql generate ${{ matrix.project.codegen }}
+      - run: dotnet test ${{ matrix.project.test }}


### PR DESCRIPTION
I've seen situations where I've gone back later and fixed the test project code, because I wasn't checking in the pull_request whether the test project builds and the test passes. So in this PR, we're going to have it checked in every push, every pull_request.