### PR TITLE
feat: make "itemSlots" GraphQL query

### DIFF
--- a/Mimir/Exceptions/KeyNotFoundInBsonDocumentException.cs
+++ b/Mimir/Exceptions/KeyNotFoundInBsonDocumentException.cs
@@ -2,7 +2,7 @@ namespace Mimir.Exceptions;
 
 public class KeyNotFoundInBsonDocumentException : Exception, IDefaultMessageException
 {
-    public const string DefaultMessage = "Key not found in BsonDocument";
+    private const string DefaultMessage = "Key not found in BsonDocument";
 
     public string GetDefaultMessage() => DefaultMessage;
 

--- a/Mimir/Exceptions/UnexpectedTypeOfBsonValueException.cs
+++ b/Mimir/Exceptions/UnexpectedTypeOfBsonValueException.cs
@@ -4,7 +4,7 @@ namespace Mimir.Exceptions;
 
 public class UnexpectedTypeOfBsonValueException : Exception, IDefaultMessageException
 {
-    public const string DefaultMessage = "Unexpected type of BsonValue";
+    private const string DefaultMessage = "Unexpected type of BsonValue";
 
     public string GetDefaultMessage() => DefaultMessage;
 

--- a/Mimir/GraphQL/Resolvers/AvatarResolver.cs
+++ b/Mimir/GraphQL/Resolvers/AvatarResolver.cs
@@ -5,6 +5,8 @@ using Mimir.GraphQL.Factories;
 using Mimir.GraphQL.Objects;
 using Mimir.Models;
 using Mimir.Repositories;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.State;
 
 namespace Mimir.GraphQL.Resolvers;
 
@@ -91,4 +93,11 @@ public class AvatarResolver
         collectionRepo.GetCollection(planetName, avatarObject.Address)
             .CollectionSheetIds.Select(CollectionElementObjectFactory.Create)
             .ToArray();
+
+    public static ItemSlotState GetItemSlot(
+        [Service] ItemSlotRepository itemSlotRepo,
+        [Parent] AvatarObject avatarObject,
+        [ScopedState("planetName")] PlanetName planetName,
+        BattleType battleType) =>
+        itemSlotRepo.GetItemSlot(planetName, avatarObject.Address, battleType);
 }

--- a/Mimir/GraphQL/Types/AgentType.cs
+++ b/Mimir/GraphQL/Types/AgentType.cs
@@ -1,6 +1,7 @@
 using Lib9c.GraphQL.Types;
 using Mimir.GraphQL.Objects;
 using Mimir.GraphQL.Resolvers;
+using Nekoyume;
 
 namespace Mimir.GraphQL.Types;
 
@@ -28,7 +29,9 @@ public class AgentType : ObjectType<AgentObject>
                 AgentResolver.GetMonsterCollectionRound(default!, default!, default!, default!, default!));
         descriptor
             .Field("avatar")
-            .Argument("index", a => a.Type<NonNullType<IntType>>())
+            .Argument("index", a => a
+                .Description($"The index of the avatar in the agent. (0 ~ {GameConfig.SlotCount - 1}).")
+                .Type<NonNullType<IntType>>())
             .Type<AvatarType>()
             .ResolveWith<AgentResolver>(_ =>
                 AgentResolver.GetAvatar(default!, default!));

--- a/Mimir/GraphQL/Types/AvatarType.cs
+++ b/Mimir/GraphQL/Types/AvatarType.cs
@@ -56,7 +56,9 @@ public class AvatarType : ObjectType<AvatarObject>
                 AvatarResolver.GetCollectionElements(default!, default!, default!));
         descriptor
             .Field("itemSlots")
-            .Argument("battleType", a => a.Type<NonNullType<EnumType<BattleType>>>())
+            .Argument("battleType", a => a
+                .Description("The type of battle that the item slot is used for.")
+                .Type<NonNullType<EnumType<BattleType>>>())
             .Type<ItemSlotType>()
             .ResolveWith<AvatarResolver>(_ =>
                 AvatarResolver.GetItemSlot(default!, default!, default!, default!));

--- a/Mimir/GraphQL/Types/AvatarType.cs
+++ b/Mimir/GraphQL/Types/AvatarType.cs
@@ -1,6 +1,7 @@
 using Lib9c.GraphQL.Types;
 using Mimir.GraphQL.Objects;
 using Mimir.GraphQL.Resolvers;
+using Nekoyume.Model.EnumType;
 
 namespace Mimir.GraphQL.Types;
 
@@ -53,5 +54,11 @@ public class AvatarType : ObjectType<AvatarObject>
             .Type<ListType<NonNullType<CollectionElementType>>>()
             .ResolveWith<AvatarResolver>(_ =>
                 AvatarResolver.GetCollectionElements(default!, default!, default!));
+        descriptor
+            .Field("itemSlots")
+            .Argument("battleType", a => a.Type<NonNullType<EnumType<BattleType>>>())
+            .Type<ItemSlotType>()
+            .ResolveWith<AvatarResolver>(_ =>
+                AvatarResolver.GetItemSlot(default!, default!, default!, default!));
     }
 }

--- a/Mimir/GraphQL/Types/ItemSlotType.cs
+++ b/Mimir/GraphQL/Types/ItemSlotType.cs
@@ -1,0 +1,24 @@
+using Lib9c.GraphQL.Types;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.State;
+
+namespace Mimir.GraphQL.Types;
+
+public class ItemSlotType : ObjectType<ItemSlotState>
+{
+    protected override void Configure(IObjectTypeDescriptor<ItemSlotState> descriptor)
+    {
+        descriptor
+            .Field(f => f.BattleType)
+            .Description("The type of battle that the item slot is used for.")
+            .Type<NonNullType<EnumType<BattleType>>>();
+        descriptor
+            .Field(f => f.Costumes)
+            .Description("The non-fungible item IDs of the costumes equipped in the item slot.")
+            .Type<NonNullType<ListType<GuidType>>>();
+        descriptor
+            .Field(f => f.Equipments)
+            .Description("The non-fungible item IDs of the equipments equipped in the item slot.")
+            .Type<NonNullType<ListType<GuidType>>>();
+    }
+}

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddSingleton<DailyRewardRepository>();
 builder.Services.AddSingleton<InventoryRepository>();
 builder.Services.AddSingleton<AllRuneRepository>();
 builder.Services.AddSingleton<CollectionRepository>();
+builder.Services.AddSingleton<ItemSlotRepository>();
 builder.Services.AddControllers();
 builder.Services.AddHeadlessGQLClient()
     .ConfigureHttpClient((provider, client) =>

--- a/Mimir/Repositories/ItemSlotRepository.cs
+++ b/Mimir/Repositories/ItemSlotRepository.cs
@@ -1,0 +1,54 @@
+using Lib9c.GraphQL.Enums;
+using Libplanet.Crypto;
+using Mimir.Exceptions;
+using Mimir.Services;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.State;
+
+namespace Mimir.Repositories;
+
+public class ItemSlotRepository(MongoDBCollectionService mongoDbCollectionService)
+    : BaseRepository<BsonDocument>(mongoDbCollectionService)
+{
+    public ItemSlotState GetItemSlot(
+        PlanetName planetName,
+        Address avatarAddress,
+        BattleType battleType)
+    {
+        var itemSlotAddress = ItemSlotState.DeriveAddress(avatarAddress, battleType);
+        var collection = GetCollection(planetName);
+        var filter = Builders<BsonDocument>.Filter.Eq("Address", itemSlotAddress.ToHex());
+        var document = collection.Find(filter).FirstOrDefault();
+        if (document is null)
+        {
+            throw new DocumentNotFoundInMongoCollectionException(
+                collection.CollectionNamespace.CollectionName,
+                $"'Address' equals to '{itemSlotAddress.ToHex()}'");
+        }
+
+        try
+        {
+            var obj = document["State"]["Object"].AsBsonDocument;
+            var costumes = obj["Costumes"].AsBsonArray
+                .Select(e => Guid.Parse(e.AsString))
+                .ToList();
+            var equipments = obj["Equipments"].AsBsonArray
+                .Select(e => Guid.Parse(e.AsString))
+                .ToList();
+            var itemSlot = new ItemSlotState(battleType);
+            itemSlot.UpdateCostumes(costumes);
+            itemSlot.UpdateEquipment(equipments);
+            return itemSlot;
+        }
+        catch (KeyNotFoundException e)
+        {
+            throw new KeyNotFoundInBsonDocumentException(
+                "document[\"State\"][\"Object\"] or its children keys \"Costumes\" and \"Equipments\"",
+                e);
+        }
+    }
+
+    protected override string GetCollectionName() => "item_slot";
+}


### PR DESCRIPTION
- Resolve #152.
- Introduce `ItemSlotRepository`.
- Register `ItemSlotRepository` to services.
- Introduce `ItemSlotType` to handle `ItemSlotState`.
- Add `itemSlots` field to `avatar` GraphQL query.
