### PR TITLE
feat: make "runeSlots" GraphQL query

### DIFF
--- a/Mimir/GraphQL/Resolvers/AvatarResolver.cs
+++ b/Mimir/GraphQL/Resolvers/AvatarResolver.cs
@@ -6,6 +6,7 @@ using Mimir.GraphQL.Objects;
 using Mimir.Models;
 using Mimir.Repositories;
 using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Rune;
 using Nekoyume.Model.State;
 
 namespace Mimir.GraphQL.Resolvers;
@@ -100,4 +101,11 @@ public class AvatarResolver
         [ScopedState("planetName")] PlanetName planetName,
         BattleType battleType) =>
         itemSlotRepo.GetItemSlot(planetName, avatarObject.Address, battleType);
+
+    public static RuneSlot[] GetRuneSlots(
+        [Service] RuneSlotRepository runeSlotRepo,
+        [Parent] AvatarObject avatarObject,
+        [ScopedState("planetName")] PlanetName planetName,
+        BattleType battleType) =>
+        runeSlotRepo.GetRuneSlots(planetName, avatarObject.Address, battleType);
 }

--- a/Mimir/GraphQL/Types/AvatarType.cs
+++ b/Mimir/GraphQL/Types/AvatarType.cs
@@ -62,5 +62,13 @@ public class AvatarType : ObjectType<AvatarObject>
             .Type<ItemSlotStateType>()
             .ResolveWith<AvatarResolver>(_ =>
                 AvatarResolver.GetItemSlot(default!, default!, default!, default!));
+        descriptor
+            .Field("runeSlots")
+            .Argument("battleType", a => a
+                .Description("The type of battle that the rune slot is used for.")
+                .Type<NonNullType<EnumType<BattleType>>>())
+            .Type<ListType<RuneSlotType>>()
+            .ResolveWith<AvatarResolver>(_ =>
+                AvatarResolver.GetRuneSlots(default!, default!, default!, default!));
     }
 }

--- a/Mimir/GraphQL/Types/AvatarType.cs
+++ b/Mimir/GraphQL/Types/AvatarType.cs
@@ -59,7 +59,7 @@ public class AvatarType : ObjectType<AvatarObject>
             .Argument("battleType", a => a
                 .Description("The type of battle that the item slot is used for.")
                 .Type<NonNullType<EnumType<BattleType>>>())
-            .Type<ItemSlotType>()
+            .Type<ItemSlotStateType>()
             .ResolveWith<AvatarResolver>(_ =>
                 AvatarResolver.GetItemSlot(default!, default!, default!, default!));
     }

--- a/Mimir/GraphQL/Types/ItemSlotStateType.cs
+++ b/Mimir/GraphQL/Types/ItemSlotStateType.cs
@@ -4,7 +4,7 @@ using Nekoyume.Model.State;
 
 namespace Mimir.GraphQL.Types;
 
-public class ItemSlotType : ObjectType<ItemSlotState>
+public class ItemSlotStateType : ObjectType<ItemSlotState>
 {
     protected override void Configure(IObjectTypeDescriptor<ItemSlotState> descriptor)
     {

--- a/Mimir/GraphQL/Types/RuneSlotType.cs
+++ b/Mimir/GraphQL/Types/RuneSlotType.cs
@@ -1,0 +1,31 @@
+using Nekoyume.Model.Rune;
+
+namespace Mimir.GraphQL.Types;
+
+public class RuneSlotType : ObjectType<RuneSlot>
+{
+    protected override void Configure(IObjectTypeDescriptor<RuneSlot> descriptor)
+    {
+        descriptor
+            .Field(f => f.Index)
+            .Description("The index of the rune slot.")
+            .Type<NonNullType<IntType>>();
+        descriptor
+            .Field(f => f.RuneSlotType)
+            .Description("The type of the rune slot.")
+            .Type<NonNullType<EnumType<Nekoyume.Model.EnumType.RuneSlotType>>>();
+        descriptor
+            .Field(f => f.RuneType)
+            .Description("The type of the rune.")
+            .Type<NonNullType<EnumType<Nekoyume.Model.EnumType.RuneType>>>();
+        descriptor
+            .Field(f => f.IsLock)
+            .Description("Whether the rune slot is locked.")
+            .Type<NonNullType<BooleanType>>();
+        descriptor
+            .Field(f => f.RuneId)
+            .Name("runeSheetId")
+            .Description("The RuneSheet ID of the rune equipped in the rune slot.")
+            .Type<IntType>();
+    }
+}

--- a/Mimir/GraphQL/Types/RuneType.cs
+++ b/Mimir/GraphQL/Types/RuneType.cs
@@ -8,9 +8,11 @@ public class RuneType : ObjectType<RuneObject>
     {
         descriptor
             .Field(f => f.RuneSheetId)
+            .Description("The RuneSheet ID of the rune.")
             .Type<NonNullType<IntType>>();
         descriptor
             .Field(f => f.Level)
+            .Description("The level of the rune.")
             .Type<NonNullType<IntType>>();
     }
 }

--- a/Mimir/Repositories/ItemSlotRepository.cs
+++ b/Mimir/Repositories/ItemSlotRepository.cs
@@ -48,6 +48,12 @@ public class ItemSlotRepository(MongoDBCollectionService mongoDbCollectionServic
                 "document[\"State\"][\"Object\"] or its children keys",
                 e);
         }
+        catch (InvalidCastException e)
+        {
+            throw new UnexpectedTypeOfBsonValueException(
+                "document[\"State\"][\"Object\"].AsBsonDocument or its children values",
+                e);
+        }
     }
 
     protected override string GetCollectionName() => "item_slot";

--- a/Mimir/Repositories/ItemSlotRepository.cs
+++ b/Mimir/Repositories/ItemSlotRepository.cs
@@ -45,7 +45,7 @@ public class ItemSlotRepository(MongoDBCollectionService mongoDbCollectionServic
         catch (KeyNotFoundException e)
         {
             throw new KeyNotFoundInBsonDocumentException(
-                "document[\"State\"][\"Object\"] or its children keys \"Costumes\" and \"Equipments\"",
+                "document[\"State\"][\"Object\"] or its children keys",
                 e);
         }
     }

--- a/Mimir/Repositories/RuneSlotRepository.cs
+++ b/Mimir/Repositories/RuneSlotRepository.cs
@@ -55,6 +55,12 @@ public class RuneSlotRepository(MongoDBCollectionService mongoDbCollectionServic
                 "document[\"State\"][\"Object\"][\"slots\"] or its children keys",
                 e);
         }
+        catch (InvalidCastException e)
+        {
+            throw new UnexpectedTypeOfBsonValueException(
+                "document[\"State\"][\"Object\"][\"slots\"].AsBsonArray or its children values",
+                e);
+        }
     }
 
     protected override string GetCollectionName() => "rune_slot";

--- a/Mimir/Repositories/RuneSlotRepository.cs
+++ b/Mimir/Repositories/RuneSlotRepository.cs
@@ -1,0 +1,61 @@
+using Lib9c.GraphQL.Enums;
+using Libplanet.Crypto;
+using Mimir.Exceptions;
+using Mimir.Services;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Nekoyume.Model.EnumType;
+using Nekoyume.Model.Rune;
+using Nekoyume.Model.State;
+
+namespace Mimir.Repositories;
+
+public class RuneSlotRepository(MongoDBCollectionService mongoDbCollectionService)
+    : BaseRepository<BsonDocument>(mongoDbCollectionService)
+{
+    public RuneSlot[] GetRuneSlots(
+        PlanetName planetName,
+        Address avatarAddress,
+        BattleType battleType)
+    {
+        var itemSlotAddress = RuneSlotState.DeriveAddress(avatarAddress, battleType);
+        var collection = GetCollection(planetName);
+        var filter = Builders<BsonDocument>.Filter.Eq("Address", itemSlotAddress.ToHex());
+        var document = collection.Find(filter).FirstOrDefault();
+        if (document is null)
+        {
+            throw new DocumentNotFoundInMongoCollectionException(
+                collection.CollectionNamespace.CollectionName,
+                $"'Address' equals to '{itemSlotAddress.ToHex()}'");
+        }
+
+        try
+        {
+            return document["State"]["Object"]["slots"].AsBsonArray
+                .Select(doc =>
+                {
+                    var slotIndex = doc["SlotIndex"].AsInt32;
+                    var runeSlotType = (RuneSlotType)doc["RuneSlotType"].AsInt32;
+                    var runeType = (RuneType)doc["RuneType"].AsInt32;
+                    var isLock = doc["IsLock"].AsBoolean;
+                    var runeSheetId = doc["RuneSheetId"].AsNullableInt32;
+                    var runeSlot = new RuneSlot(slotIndex, runeSlotType, runeType, isLock);
+                    if (runeSheetId.HasValue)
+                    {
+                        runeSlot.Equip(runeSheetId.Value);
+                    }
+
+                    return runeSlot;
+                })
+                .ToArray();
+        }
+        catch (KeyNotFoundException e)
+        {
+            throw new KeyNotFoundInBsonDocumentException(
+                "document[\"State\"][\"Object\"][\"slots\"] or its children keys",
+                e);
+        }
+    }
+
+    protected override string GetCollectionName() => "rune_slot";
+}


### PR DESCRIPTION
- Resolve #169.
- Rename `ItemSlotType` to `ItemSlotStateType`.
- Introduce `RuneSlotRepository`.
- Introduce `RuneSlotType`.
- Resolve rune slots from `AvatarResolver`.
- Add `runeSlots` field to `avatar` GraphQL query.
