### PR TITLE
feat: make `stake` GraphQL query

### DIFF
--- a/Lib9c.GraphQL/Types/StatMapType.cs
+++ b/Lib9c.GraphQL/Types/StatMapType.cs
@@ -7,7 +7,7 @@ public class StatMapType : ObjectType<StatMap>
 {
     protected override void Configure(IObjectTypeDescriptor<StatMap> descriptor)
     {
-        descriptor.BindFields(BindingBehavior.Explicit);
+        descriptor.BindFieldsExplicitly();
         descriptor
             .Field(f => f.HP)
             .Type<NonNullType<LongType>>();

--- a/Mimir/GraphQL/Resolvers/AgentResolver.cs
+++ b/Mimir/GraphQL/Resolvers/AgentResolver.cs
@@ -5,6 +5,7 @@ using Mimir.GraphQL.Objects;
 using Mimir.Models;
 using Mimir.Repositories;
 using Nekoyume;
+using Nekoyume.Model.Stake;
 
 namespace Mimir.GraphQL.Resolvers;
 
@@ -69,5 +70,14 @@ public class AgentResolver
                 agentAddress,
                 tuple.index))
             .ToList();
+    }
+
+    public static StakeStateV2 GetStake(
+        [Service] StakeRepository stakeRepo,
+        [Parent] AgentObject agentObject,
+        [ScopedState("planetName")] PlanetName planetName)
+    {
+        var agentAddress = agentObject.Address;
+        return stakeRepo.GetStakeState(planetName, agentAddress);
     }
 }

--- a/Mimir/GraphQL/Types/AgentType.cs
+++ b/Mimir/GraphQL/Types/AgentType.cs
@@ -33,12 +33,14 @@ public class AgentType : ObjectType<AgentObject>
                 .Description($"The index of the avatar in the agent. (0 ~ {GameConfig.SlotCount - 1}).")
                 .Type<NonNullType<IntType>>())
             .Type<AvatarType>()
-            .ResolveWith<AgentResolver>(_ =>
-                AgentResolver.GetAvatar(default!, default!));
+            .ResolveWith<AgentResolver>(_ => AgentResolver.GetAvatar(default!, default!));
         descriptor
             .Field("avatars")
             .Type<NonNullType<ListType<NonNullType<AvatarType>>>>()
-            .ResolveWith<AgentResolver>(_ =>
-                AgentResolver.GetAvatars(default!));
+            .ResolveWith<AgentResolver>(_ => AgentResolver.GetAvatars(default!));
+        descriptor
+            .Field("stake")
+            .Type<StakeStateType>()
+            .ResolveWith<AgentResolver>(_ => AgentResolver.GetStake(default!, default!, default!));
     }
 }

--- a/Mimir/GraphQL/Types/ContractType.cs
+++ b/Mimir/GraphQL/Types/ContractType.cs
@@ -1,0 +1,27 @@
+using Nekoyume.Model.Stake;
+
+namespace Mimir.GraphQL.Types;
+
+public class ContractType : ObjectType<Contract>
+{
+    protected override void Configure(IObjectTypeDescriptor<Contract> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+        descriptor
+            .Field(f => f.StakeRegularFixedRewardSheetTableName)
+            .Description("The name of the table that contains the regular fixed rewards for staking.")
+            .Type<NonNullType<StringType>>();
+        descriptor
+            .Field(f => f.StakeRegularRewardSheetTableName)
+            .Description("The name of the table that contains the regular rewards for staking.")
+            .Type<NonNullType<StringType>>();
+        descriptor
+            .Field(f => f.RewardInterval)
+            .Description("The interval at which rewards are given.")
+            .Type<NonNullType<LongType>>();
+        descriptor
+            .Field(f => f.LockupInterval)
+            .Description("The interval at which the stake is locked up.")
+            .Type<NonNullType<LongType>>();
+    }
+}

--- a/Mimir/GraphQL/Types/ItemSlotStateType.cs
+++ b/Mimir/GraphQL/Types/ItemSlotStateType.cs
@@ -8,6 +8,7 @@ public class ItemSlotStateType : ObjectType<ItemSlotState>
 {
     protected override void Configure(IObjectTypeDescriptor<ItemSlotState> descriptor)
     {
+        descriptor.BindFieldsExplicitly();
         descriptor
             .Field(f => f.BattleType)
             .Description("The type of battle that the item slot is used for.")

--- a/Mimir/GraphQL/Types/RuneSlotType.cs
+++ b/Mimir/GraphQL/Types/RuneSlotType.cs
@@ -6,6 +6,7 @@ public class RuneSlotType : ObjectType<RuneSlot>
 {
     protected override void Configure(IObjectTypeDescriptor<RuneSlot> descriptor)
     {
+        descriptor.BindFieldsExplicitly();
         descriptor
             .Field(f => f.Index)
             .Description("The index of the rune slot.")

--- a/Mimir/GraphQL/Types/StakeStateType.cs
+++ b/Mimir/GraphQL/Types/StakeStateType.cs
@@ -1,0 +1,35 @@
+using Nekoyume.Model.Stake;
+
+namespace Mimir.GraphQL.Types;
+
+public class StakeStateType : ObjectType<StakeStateV2>
+{
+    protected override void Configure(IObjectTypeDescriptor<StakeStateV2> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+        descriptor
+            .Field(f => f.Contract)
+            .Description("The contract of the stake.")
+            .Type<NonNullType<ContractType>>();
+        descriptor
+            .Field(f => f.StartedBlockIndex)
+            .Description("The block index when the stake started.")
+            .Type<NonNullType<LongType>>();
+        descriptor
+            .Field(f => f.ReceivedBlockIndex)
+            .Description("The block index when the stake received. If 0, the stake is not received yet.")
+            .Type<NonNullType<LongType>>();
+        descriptor
+            .Field(f => f.CancellableBlockIndex)
+            .Description("The block index when the stake can be cancelled.")
+            .Type<NonNullType<LongType>>();
+        descriptor
+            .Field(f => f.ClaimableBlockIndex)
+            .Description("The block index when the stake can be claimed.")
+            .Type<NonNullType<LongType>>();
+        descriptor
+            .Field(f => f.ClaimedBlockIndex)
+            .Description("The block index when the stake was claimed. If 0, the stake is not claimed yet.")
+            .Type<NonNullType<LongType>>();
+    }
+}

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -37,6 +37,8 @@ builder.Services.AddSingleton<InventoryRepository>();
 builder.Services.AddSingleton<AllRuneRepository>();
 builder.Services.AddSingleton<CollectionRepository>();
 builder.Services.AddSingleton<ItemSlotRepository>();
+builder.Services.AddSingleton<RuneSlotRepository>();
+builder.Services.AddSingleton<StakeRepository>();
 builder.Services.AddControllers();
 builder.Services.AddHeadlessGQLClient()
     .ConfigureHttpClient((provider, client) =>

--- a/Mimir/Repositories/StakeRepository.cs
+++ b/Mimir/Repositories/StakeRepository.cs
@@ -1,0 +1,55 @@
+using Lib9c.GraphQL.Enums;
+using Libplanet.Crypto;
+using Mimir.Exceptions;
+using Mimir.GraphQL.Extensions;
+using Mimir.Services;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Nekoyume.Model.Stake;
+
+namespace Mimir.Repositories;
+
+public class StakeRepository(MongoDBCollectionService mongoDbCollectionService)
+    : BaseRepository<BsonDocument>(mongoDbCollectionService)
+{
+    public StakeStateV2 GetStakeState(PlanetName planetName, Address agentAddress)
+    {
+        var collection = GetCollection(planetName);
+        var filter = Builders<BsonDocument>.Filter.Eq("Address", agentAddress.ToHex());
+        var document = collection.Find(filter).FirstOrDefault();
+        if (document is null)
+        {
+            throw new DocumentNotFoundInMongoCollectionException(
+                collection.CollectionNamespace.CollectionName,
+                $"'Address' equals to '{agentAddress.ToHex()}'");
+        }
+
+        try
+        {
+            var doc = document["State"]["Object"].AsBsonDocument;
+            var contractDoc = doc["Contract"].AsBsonDocument;
+            var contract = new Contract(
+                contractDoc["StakeRegularFixedRewardSheetTableName"].AsString,
+                contractDoc["StakeRegularRewardSheetTableName"].AsString,
+                contractDoc["RewardInterval"].ToLong(),
+                contractDoc["LockupInterval"].ToLong());
+            var startedBlockIndex = doc["StartedBlockIndex"].ToLong();
+            var receivedBlockIndex = doc["ReceivedBlockIndex"].ToLong();
+            return new StakeStateV2(contract, startedBlockIndex, receivedBlockIndex);
+        }
+        catch (KeyNotFoundException e)
+        {
+            throw new KeyNotFoundInBsonDocumentException(
+                "document[\"State\"][\"Object\"] or its children keys",
+                e);
+        }
+        catch (InvalidCastException e)
+        {
+            throw new UnexpectedTypeOfBsonValueException(
+                "document[\"State\"][\"Object\"].AsBsonDocument or its children values",
+                e);
+        }
+    }
+
+    protected override string GetCollectionName() => "stake";
+}


### PR DESCRIPTION
- Resolve #153.
- Introduce `StakeRepository`.
- Register repositories to services.
- Introduce `ContractType` and `StakeStateType`.
- Resolve `StakeStateV2` in `AgentResolver`.
- Add "stake" field to "agent" GraphQL query.
