### PR TITLE
fix: consider when `IAction` is not `GameAction` in  `BlockPoller` and `BaseActionHandler`

### DIFF
--- a/Mimir.Worker/Exceptions/InvalidTypeOfActionPlainValueInternal.cs
+++ b/Mimir.Worker/Exceptions/InvalidTypeOfActionPlainValueInternal.cs
@@ -1,0 +1,22 @@
+namespace Mimir.Worker.Exceptions;
+
+public class InvalidTypeOfActionPlainValueInternalException : Exception
+{
+    public InvalidTypeOfActionPlainValueInternalException(
+        string? message,
+        Exception? innerException = null) :
+        base(message, innerException)
+    {
+    }
+
+    public InvalidTypeOfActionPlainValueInternalException(
+        Bencodex.Types.ValueKind[] expected,
+        Bencodex.Types.ValueKind? actual,
+        Exception? innerException = null) :
+        base(
+            $"Invalid type of action plain value internal." +
+            $" Expected: {string.Join(", ", expected)}, Actual: {actual?.ToString() ?? "null"}",
+            innerException)
+    {
+    }
+}

--- a/Mimir.Worker/Handler/BaseActionHandler.cs
+++ b/Mimir.Worker/Handler/BaseActionHandler.cs
@@ -26,8 +26,8 @@ public abstract class BaseActionHandler(
         long blockIndex,
         Address signer,
         IAction action,
-        string? actionType,
-        Dictionary? actionPlainValueInternal)
+        IValue? actionType,
+        IValue? actionPlainValueInternal)
     {
         try
         {
@@ -39,9 +39,14 @@ public abstract class BaseActionHandler(
             // ignored
         }
 
-        if (actionType is null ||
-            string.IsNullOrEmpty(actionType) ||
-            !Regex.IsMatch(actionType, actionTypeRegex))
+        var actionTypeStr = actionType switch
+        {
+            Integer integer => integer.ToString(),
+            Text text => (string)text,
+            _ => null
+        };
+        if (actionTypeStr is null ||
+            !Regex.IsMatch(actionTypeStr, actionTypeRegex))
         {
             return false;
         }
@@ -49,13 +54,14 @@ public abstract class BaseActionHandler(
         try
         {
             await HandleAction(
-                actionType,
+                actionTypeStr,
                 blockIndex,
-                actionPlainValueInternal ?? Dictionary.Empty);
+                actionPlainValueInternal);
         }
         catch (NotImplementedException)
         {
             // ignored
+            return false;
         }
 
         return false;
@@ -72,7 +78,7 @@ public abstract class BaseActionHandler(
     protected virtual Task HandleAction(
         string actionType,
         long processBlockIndex,
-        Dictionary actionValues)
+        IValue? actionPlainValueInternal)
     {
         throw new NotImplementedException();
     }

--- a/Mimir.Worker/Handler/ProductsHandler.cs
+++ b/Mimir.Worker/Handler/ProductsHandler.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Bencodex.Types;
 using Libplanet.Crypto;
+using Mimir.Worker.Exceptions;
 using Mimir.Worker.Models;
 using Mimir.Worker.Services;
 using Nekoyume.Battle;
@@ -26,9 +27,15 @@ public class ProductsHandler(IStateService stateService, MongoDbService store)
     protected override async Task HandleAction(
         string actionType,
         long processBlockIndex,
-        Dictionary actionValues
-    )
+        IValue? actionPlainValueInternal)
     {
+        if (actionPlainValueInternal is not Dictionary actionValues)
+        {
+            throw new InvalidTypeOfActionPlainValueInternalException(
+                [ValueKind.Dictionary],
+                actionPlainValueInternal?.Kind);
+        }
+
         var avatarAddresses = GetAvatarAddresses(actionType, actionValues);
 
         foreach (var avatarAddress in avatarAddresses)

--- a/Mimir.Worker/Program.cs
+++ b/Mimir.Worker/Program.cs
@@ -79,14 +79,17 @@ builder.Services.AddHostedService(serviceProvider =>
 
 var host = builder.Build();
 var config = host.Services.GetRequiredService<IOptions<Configuration>>().Value;
-SentrySdk.Init(options =>
+if (!string.IsNullOrEmpty(config.SentryDsn))
 {
-    options.Dsn = config.SentryDsn;
-    options.Debug = config.SentryDebug;
-    options.AutoSessionTracking = true;
-    options.TracesSampleRate = 1.0;
-    options.ProfilesSampleRate = 1.0;
-    options.AddIntegration(new ProfilingIntegration(TimeSpan.FromMilliseconds(500)));
-});
+    SentrySdk.Init(options =>
+    {
+        options.Dsn = config.SentryDsn;
+        options.Debug = config.SentryDebug;
+        options.AutoSessionTracking = true;
+        options.TracesSampleRate = 1.0;
+        options.ProfilesSampleRate = 1.0;
+        options.AddIntegration(new ProfilingIntegration(TimeSpan.FromMilliseconds(500)));
+    });    
+}
 
 host.Run();


### PR DESCRIPTION
- Introduce `InvalidTypeOfActionPlainValueInternalException`.
- Fix arguments of `BaseActionHandler.TryHandleAction()` method.
- Consider when `Config.SentryDsn` is null or empty.
