### PR TITLE
feat: make more sub fields in the "arena" GraphQL query

### DIFF
--- a/Mimir/Arena/AvatarStatesForArena.cs
+++ b/Mimir/Arena/AvatarStatesForArena.cs
@@ -9,7 +9,11 @@ public record AvatarStatesForArena
     public AllRuneState RuneStates { get; private set; }
     public RuneSlotState RuneSlotState { get; private set; }
 
-    public AvatarStatesForArena(AvatarState avatarState, ItemSlotState itemSlotState, AllRuneState runeStates, RuneSlotState runeSlotState)
+    public AvatarStatesForArena(
+        AvatarState avatarState,
+        ItemSlotState itemSlotState,
+        AllRuneState runeStates,
+        RuneSlotState runeSlotState)
     {
         AvatarState = avatarState;
         ItemSlotState = itemSlotState;

--- a/Mimir/Controllers/ArenaController.cs
+++ b/Mimir/Controllers/ArenaController.cs
@@ -41,7 +41,7 @@ public class ArenaController(
         [BindRequired] int round
     )
     {
-        var rank = await arenaRankingRepository.GetRankByAvatarAddress(
+        var rank = await arenaRankingRepository.GetRankingByAvatarAddressAsync(
             network,
             new Address(avatarAddress),
             championshipId,
@@ -67,8 +67,8 @@ public class ArenaController(
     {
         return await arenaRankingRepository.GetRanking(
             network,
-            limit,
             offset,
+            limit,
             championshipId,
             round
         );

--- a/Mimir/GraphQL/Resolvers/ArenaResolver.cs
+++ b/Mimir/GraphQL/Resolvers/ArenaResolver.cs
@@ -57,6 +57,25 @@ public class ArenaResolver
         [ScopedState("planetName")] PlanetName planetName,
         [ScopedState("arenaRound")] ArenaSheet.RoundData? arenaRound)
     {
+        if (ranking < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ranking),
+                "This must be greater than or equal to 1.");
+        }
+
+        switch (length)
+        {
+            case < 1:
+                throw new ArgumentOutOfRangeException(
+                    nameof(length),
+                    "This must be greater than or equal to 1.");
+            case > 100:
+                throw new ArgumentOutOfRangeException(
+                    nameof(length),
+                    "This must be less than or equal to 100.");
+        }
+
         arenaRound ??= GetArenaRound(context, metadataRepo, tableSheetsRepo, planetName, arenaRound);
         return await arenaRankingRepo.GetRanking(
             planetName,

--- a/Mimir/GraphQL/Resolvers/ArenaResolver.cs
+++ b/Mimir/GraphQL/Resolvers/ArenaResolver.cs
@@ -1,6 +1,7 @@
 using HotChocolate.Resolvers;
 using Lib9c.GraphQL.Enums;
 using Libplanet.Crypto;
+using Mimir.Models.Arena;
 using Mimir.Repositories;
 using Nekoyume.TableData;
 
@@ -46,19 +47,23 @@ public class ArenaResolver
             : rank;
     }
 
-    public static int GetRound(
+    public static async Task<List<ArenaRanking>> GetLeaderboard(
         IResolverContext context,
+        long ranking,
+        int length,
+        [Service] ArenaRankingRepository arenaRankingRepo,
         [Service] MetadataRepository metadataRepo,
         [Service] TableSheetsRepository tableSheetsRepo,
         [ScopedState("planetName")] PlanetName planetName,
-        [ScopedState("arenaRound")] ArenaSheet.RoundData? arenaRound) =>
-        GetArenaRound(context, metadataRepo, tableSheetsRepo, planetName, arenaRound).Round;
-
-    // public static int? GetRank(
-    //     IResolverContext context,
-    //     [Service] MetadataRepository metadataRepo,
-    //     [Service] TableSheetsRepository tableSheetsRepo,
-    //     [ScopedState("planetName")] PlanetName planetName,
-    //     [ScopedState("arenaRound")] ArenaSheet.RoundData? arenaRound) =>
-    //     GetArenaRound(context, metadataRepo, tableSheetsRepo, planetName, arenaRound)?.round;
+        [ScopedState("arenaRound")] ArenaSheet.RoundData? arenaRound)
+    {
+        arenaRound ??= GetArenaRound(context, metadataRepo, tableSheetsRepo, planetName, arenaRound);
+        return await arenaRankingRepo.GetRanking(
+            planetName,
+            ranking - 1,
+            length,
+            arenaRound.ChampionshipId,
+            arenaRound.Round
+        );
+    }
 }

--- a/Mimir/GraphQL/Resolvers/ArenaResolver.cs
+++ b/Mimir/GraphQL/Resolvers/ArenaResolver.cs
@@ -1,5 +1,6 @@
 using HotChocolate.Resolvers;
 using Lib9c.GraphQL.Enums;
+using Libplanet.Crypto;
 using Mimir.Repositories;
 using Nekoyume.TableData;
 
@@ -25,13 +26,25 @@ public class ArenaResolver
         return arenaRound;
     }
 
-    public static int GetArenaSheetId(
+    public static async Task<long?> GetRanking(
         IResolverContext context,
+        Address avatarAddress,
+        [Service] ArenaRankingRepository arenaRankingRepo,
         [Service] MetadataRepository metadataRepo,
         [Service] TableSheetsRepository tableSheetsRepo,
         [ScopedState("planetName")] PlanetName planetName,
-        [ScopedState("arenaRound")] ArenaSheet.RoundData? arenaRound) =>
-        GetArenaRound(context, metadataRepo, tableSheetsRepo, planetName, arenaRound).ChampionshipId;
+        [ScopedState("arenaRound")] ArenaSheet.RoundData? arenaRound)
+    {
+        arenaRound ??= GetArenaRound(context, metadataRepo, tableSheetsRepo, planetName, arenaRound);
+        var rank = await arenaRankingRepo.GetRankingByAvatarAddressAsync(
+            planetName,
+            avatarAddress,
+            arenaRound.ChampionshipId,
+            arenaRound.Round);
+        return rank == 0
+            ? null
+            : rank;
+    }
 
     public static int GetRound(
         IResolverContext context,

--- a/Mimir/GraphQL/Types/ArenaType.cs
+++ b/Mimir/GraphQL/Types/ArenaType.cs
@@ -1,5 +1,7 @@
+using Lib9c.GraphQL.Types;
 using Mimir.GraphQL.Objects;
 using Mimir.GraphQL.Resolvers;
+using Mimir.Models.Arena;
 
 namespace Mimir.GraphQL.Types;
 
@@ -20,5 +22,20 @@ public class ArenaType : ObjectType<ArenaObject>
             .Type<LongType>()
             .ResolveWith<ArenaResolver>(_ =>
                 ArenaResolver.GetRanking(default!, default!, default!, default!, default!, default!, default!));
+        descriptor
+            .Field("leaderboard")
+            .Description("The leaderboard of the arena.")
+            .Argument("ranking", a => a
+                .Description("The ranking of the first avatar. default is 1.")
+                .Type<NonNullType<LongType>>()
+                .DefaultValue(1))
+            .Argument("length", a => a
+                .Description("The number of avatars. default is 10.")
+                .Type<NonNullType<IntType>>()
+                .DefaultValue(10))
+            .Type<ListType<ObjectType<ArenaRanking>>>()
+            .ResolveWith<ArenaResolver>(_ =>
+                ArenaResolver.GetLeaderboard(
+                    default!, default!, default!, default!, default!, default!, default!, default!));
     }
 }

--- a/Mimir/GraphQL/Types/ArenaType.cs
+++ b/Mimir/GraphQL/Types/ArenaType.cs
@@ -13,5 +13,12 @@ public class ArenaType : ObjectType<ArenaObject>
             .Type<ArenaSheetRoundDataType>()
             .ResolveWith<ArenaResolver>(_ =>
                 ArenaResolver.GetArenaRound(default!, default!, default!, default!, default!));
+        descriptor
+            .Field("ranking")
+            .Description("The avatar's ranking of the arena.")
+            .Argument("avatarAddress", a => a.Type<NonNullType<AddressType>>())
+            .Type<LongType>()
+            .ResolveWith<ArenaResolver>(_ =>
+                ArenaResolver.GetRanking(default!, default!, default!, default!, default!, default!, default!));
     }
 }

--- a/Mimir/GraphQL/Types/ArenaType.cs
+++ b/Mimir/GraphQL/Types/ArenaType.cs
@@ -26,11 +26,11 @@ public class ArenaType : ObjectType<ArenaObject>
             .Field("leaderboard")
             .Description("The leaderboard of the arena.")
             .Argument("ranking", a => a
-                .Description("The ranking of the first avatar. default is 1.")
+                .Description("The ranking of the first avatar. default is 1. This must be greater than or equal to 1.")
                 .Type<NonNullType<LongType>>()
                 .DefaultValue(1))
             .Argument("length", a => a
-                .Description("The number of avatars. default is 10.")
+                .Description("The number of avatars. default is 10. This must be greater than or equal to 1 and less than or equal to 100.")
                 .Type<NonNullType<IntType>>()
                 .DefaultValue(10))
             .Type<ListType<ObjectType<ArenaRanking>>>()


### PR DESCRIPTION
- Relates with #97.
- Refactor `ArenaRankingRepository`
- Add `ranking` and `leaderboard` fields to `arena` GraphQL query.
- Improve `TableSheetsRepository`.

# Examples

## ranking
```graphql
query arenaRank {
  arena(planetName: ODIN) {
    ranking(avatarAddress: "DEEaF9d47575FD29F72Aa50E36f59A213447e959")
  }
}
```
```json
{
  "data": {
    "arena": {
      "ranking": 758
    }
  }
}
```

## leaderboard
I'm trying to use a feature that already exists, but it's timing out. In this PR, I ignore it and move on.
```graphql
query arenaLeaderboards {
  arena(planetName: ODIN) {
    leaderboard(ranking: 1, length: 10) {
      score
    }
  }
}
```
```json
{
  "errors": [
    {
      "message": "The request exceeded the configured timeout of `00:00:30`.",
      "extensions": {
        "code": "HC0045"
      }
    }
  ]
}
```