### PR TITLE
Handle several currency balances

### DIFF
--- a/Mimir.Worker/Constants/CollectionNames.cs
+++ b/Mimir.Worker/Constants/CollectionNames.cs
@@ -10,7 +10,6 @@ using WorldBossState = Mimir.Worker.Models.WorldBossState;
 using RaiderState = Mimir.Worker.Models.RaiderState;
 using StakeState = Mimir.Worker.Models.StakeState;
 using CombinationSlotState = Mimir.Worker.Models.CombinationSlotState;
-using GoldBalanceState = Mimir.Worker.Models.GoldBalanceState;
 
 namespace Mimir.Worker.Constants
 {
@@ -40,7 +39,14 @@ namespace Mimir.Worker.Constants
             CollectionMappings.Add(typeof(RaiderState), "raider");
             CollectionMappings.Add(typeof(StakeState), "stake");
             CollectionMappings.Add(typeof(CombinationSlotState), "combination_slot");
-            CollectionMappings.Add(typeof(GoldBalanceState), "gold_balance");
+
+            // The `Raw` fields of the documents' in 'balances' collection,
+            // will not have the original state.  In Libplanet implementation,
+            // each currency has an account trie. And their states' raw value
+            // may be `Bencodex.Types.Integer`-typed. But `BalanceState` stores
+            // serialized `FungibleAssetValue` instead of `Integer` to query
+            // easily without fetching `Currency` from other source.
+            CollectionMappings.Add(typeof(BalanceState), "balances");
         }
 
         public static string GetCollectionName<T>()

--- a/Mimir.Worker/Handler/AddressHandlerMappings.cs
+++ b/Mimir.Worker/Handler/AddressHandlerMappings.cs
@@ -25,6 +25,15 @@ public static class AddressHandlerMappings
         HandlerMappings.Add(Addresses.DailyReward, new DailyRewardStateHandler());
         
         RegisterBalanceHandler(OdinNCGCurrency);
+        RegisterBalanceHandler(Currencies.Crystal);
+        RegisterBalanceHandler(Currencies.StakeRune);
+        RegisterBalanceHandler(Currencies.DailyRewardRune);
+        RegisterBalanceHandler(Currencies.Garage);
+        RegisterBalanceHandler(Currencies.Mead);
+        RegisterBalanceHandler(Currencies.FreyaBlessingRune);
+        RegisterBalanceHandler(Currencies.FreyaLiberationRune);
+        RegisterBalanceHandler(Currencies.OdinWeaknessRune);
+        RegisterBalanceHandler(Currencies.OdinWisdomRune);
     }
 
     private static void RegisterBalanceHandler(Currency currency)

--- a/Mimir.Worker/Handler/AddressHandlerMappings.cs
+++ b/Mimir.Worker/Handler/AddressHandlerMappings.cs
@@ -10,7 +10,7 @@ public static class AddressHandlerMappings
 {
     public static readonly Dictionary<Address, IStateHandler<StateData>> HandlerMappings = new();
 
-    public static readonly string NCGCurrencyAddress = "0xd6663d0EEC2a7c59FF3cfe3089abF8FEd383227D";
+    public static readonly Currency OdinNCGCurrency = Currency.Legacy("NCG", 2, new Address("0x47d082a115c63e7b58b1532d20e631538eafadde")); 
 
     static AddressHandlerMappings()
     {
@@ -23,10 +23,16 @@ public static class AddressHandlerMappings
         HandlerMappings.Add(Addresses.RuneState, new AllRuneStateHandler());
         HandlerMappings.Add(Addresses.Collection, new CollectionStateHandler());
         HandlerMappings.Add(Addresses.DailyReward, new DailyRewardStateHandler());
+        
+        RegisterBalanceHandler(OdinNCGCurrency);
+    }
+
+    private static void RegisterBalanceHandler(Currency currency)
+    {
         HandlerMappings.Add(
-            new Address(NCGCurrencyAddress),
+            new Address(currency.Hash.ToByteArray()),
 #pragma warning disable CS0618 // Type or member is obsolete
-            new BalanceHandler(Currency.Legacy("NCG", 2, new Address("0x47d082a115c63e7b58b1532d20e631538eafadde")))
+            new BalanceHandler(currency)
 #pragma warning restore CS0618 // Type or member is obsolete
         );
     }

--- a/Mimir.Worker/Handler/AddressHandlerMappings.cs
+++ b/Mimir.Worker/Handler/AddressHandlerMappings.cs
@@ -1,4 +1,6 @@
+using Lib9c;
 using Libplanet.Crypto;
+using Libplanet.Types.Assets;
 using Mimir.Worker.Models;
 using Nekoyume;
 
@@ -23,7 +25,9 @@ public static class AddressHandlerMappings
         HandlerMappings.Add(Addresses.DailyReward, new DailyRewardStateHandler());
         HandlerMappings.Add(
             new Address(NCGCurrencyAddress),
-            new GoldBalanceHandler()
+#pragma warning disable CS0618 // Type or member is obsolete
+            new BalanceHandler(Currency.Legacy("NCG", 2, new Address("0x47d082a115c63e7b58b1532d20e631538eafadde")))
+#pragma warning restore CS0618 // Type or member is obsolete
         );
     }
 }

--- a/Mimir.Worker/Handler/BalanceHandler.cs
+++ b/Mimir.Worker/Handler/BalanceHandler.cs
@@ -1,13 +1,12 @@
 using Bencodex.Types;
 using Libplanet.Crypto;
+using Libplanet.Types.Assets;
 using Mimir.Worker.Models;
 using Mimir.Worker.Services;
-using Nekoyume.Model.State;
-using GoldBalanceState = Mimir.Worker.Models.GoldBalanceState;
 
 namespace Mimir.Worker.Handler;
 
-public class GoldBalanceHandler : IStateHandler<StateData>
+public record BalanceHandler(Currency Currency) : IStateHandler<StateData>
 {
     public StateData ConvertToStateData(StateDiffContext context)
     {
@@ -15,7 +14,7 @@ public class GoldBalanceHandler : IStateHandler<StateData>
         return new StateData(context.Address, goldBalance);
     }
 
-    private GoldBalanceState ConvertToState(Address address, IValue state)
+    private BalanceState ConvertToState(Address address, IValue state)
     {
         if (state is not Integer value)
         {
@@ -24,7 +23,7 @@ public class GoldBalanceHandler : IStateHandler<StateData>
             );
         }
 
-        return new GoldBalanceState(address, value.ToBigInteger());
+        return new BalanceState(address, FungibleAssetValue.FromRawValue(Currency, value));
     }
 
     public async Task StoreStateData(MongoDbService store, StateData stateData)

--- a/Mimir.Worker/Models/State/BalanceState.cs
+++ b/Mimir.Worker/Models/State/BalanceState.cs
@@ -1,13 +1,13 @@
-using System.Numerics;
 using Bencodex.Types;
 using Libplanet.Crypto;
+using Libplanet.Types.Assets;
 using Nekoyume.Model.State;
 
 namespace Mimir.Worker.Models;
 
-public class GoldBalanceState(Address address, BigInteger value) : State(address)
+public class BalanceState(Address address, FungibleAssetValue value) : State(address)
 {
-    public BigInteger Object { get; set; } = value;
+    public FungibleAssetValue Object { get; set; } = value;
 
     public override IValue Serialize()
     {


### PR DESCRIPTION
## Description

This pull request:

  - Generalize balance handler. Now, it can register balance handler with only `Currency`. (`RegisterBalanceHandler(Currency)`).
  - Now worker stores several balances in `balances` collection.
    - OdinNCGCurrency
    - Crystal
	- StakeRune
	- DailyRewardRune
	- Garage
	- Mead
	- FreyaBlessingRune
	- FreyaLiberationRune
	- OdinWeaknessRune
	- OdinWisdomRune

## local test

I run `Mimir.Worker` in my local environment, it seems to work.

<img width="1170" alt="image" src="https://github.com/planetarium/mimir/assets/26626194/4b7e7fb6-ed68-4bba-b0e8-c02aa8e9a6fe">
