### PR TITLE
Replace content type constants with pre-defiend constants

### DIFF
--- a/Mimir/Controllers/AgentController.cs
+++ b/Mimir/Controllers/AgentController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using Lib9c;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
@@ -33,7 +34,7 @@ public class AgentController : ControllerBase
                 out var errorMessage))
         {
             Response.StatusCode = StatusCodes.Status400BadRequest;
-            Response.ContentType = "application/json";
+            Response.ContentType = MediaTypeNames.Application.Json;
             await Response.WriteAsJsonAsync(new { message = errorMessage });
             return null;
         }
@@ -60,7 +61,7 @@ public class AgentController : ControllerBase
                 out var errorMessage))
         {
             Response.StatusCode = StatusCodes.Status400BadRequest;
-            Response.ContentType = "application/json";
+            Response.ContentType = MediaTypeNames.Application.Json;
             await Response.WriteAsJsonAsync(new { message = errorMessage });
             return new AvatarsResponse([]);
         }

--- a/Mimir/Controllers/AvatarController.cs
+++ b/Mimir/Controllers/AvatarController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using System.Numerics;
 using Bencodex;
 using Libplanet.Common;
@@ -110,7 +111,7 @@ public class AvatarController(AvatarRepository avatarRepository, InventoryReposi
                 out var errorMessage))
         {
             Response.StatusCode = StatusCodes.Status400BadRequest;
-            Response.ContentType = "application/json";
+            Response.ContentType = MediaTypeNames.Application.Json;
             await Response.WriteAsJsonAsync(new { message = errorMessage });
             return null;
         }
@@ -144,7 +145,7 @@ public class AvatarController(AvatarRepository avatarRepository, InventoryReposi
                 out var errorMessage))
         {
             Response.StatusCode = StatusCodes.Status400BadRequest;
-            Response.ContentType = "application/json";
+            Response.ContentType = MediaTypeNames.Application.Json;
             await Response.WriteAsJsonAsync(new { message = errorMessage });
             return null;
         }

--- a/Mimir/Controllers/BalanceController.cs
+++ b/Mimir/Controllers/BalanceController.cs
@@ -1,3 +1,4 @@
+using System.Net.Mime;
 using Lib9c;
 using Libplanet.Crypto;
 using Libplanet.Types.Assets;
@@ -33,7 +34,7 @@ public class BalanceController : ControllerBase
                 out var errorMessage))
         {
             Response.StatusCode = StatusCodes.Status400BadRequest;
-            Response.ContentType = "application/json";
+            Response.ContentType = MediaTypeNames.Application.Json;
             await Response.WriteAsJsonAsync(new { message = errorMessage });
             return null;
         }

--- a/Mimir/Controllers/TableSheetsController.cs
+++ b/Mimir/Controllers/TableSheetsController.cs
@@ -1,4 +1,6 @@
+using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Mimir.Enums;
 using Mimir.Repositories;
 
@@ -13,14 +15,15 @@ public class TableSheetsController(TableSheetsRepository tableSheetsRepository) 
         tableSheetsRepository.GetSheetNames(network);
 
     [HttpGet("{sheetName}")]
-    [Produces("application/json", "text/csv")]
+    [Produces(MediaTypeNames.Application.Json, MediaTypeNames.Text.Csv)]
     public async Task<IActionResult> GetSheet(string network, string sheetName)
     {
         var acceptHeader = Request.Headers["Accept"].ToString();
+
         SheetFormat? sheetFormatNullable = acceptHeader switch
         {
-            "text/csv" => SheetFormat.Csv,
-            "application/json" => SheetFormat.Json,
+            MediaTypeNames.Text.Csv => SheetFormat.Csv,
+            MediaTypeNames.Application.Json => SheetFormat.Json,
             _ => null,
         };
 

--- a/Mimir/Enums/SheetFormat.cs
+++ b/Mimir/Enums/SheetFormat.cs
@@ -1,3 +1,5 @@
+using System.Net.Mime;
+
 namespace Mimir.Enums
 {
     public enum SheetFormat
@@ -13,9 +15,9 @@ namespace Mimir.Enums
             switch (format)
             {
                 case SheetFormat.Csv:
-                    return "text/csv";
+                    return MediaTypeNames.Text.Csv;
                 case SheetFormat.Json:
-                    return "application/json";
+                    return MediaTypeNames.Application.Json;
                 default:
                     throw new KeyNotFoundException(format.ToString());
             }


### PR DESCRIPTION
This pull request replaces `"application/json"` and `"text/csv"` with [`MediaTypeNames`](https://learn.microsoft.com/en-us/dotnet/api/system.net.mime.mediatypenames?view=net-8.0)' fields.