### PR TITLE
feat: Introduce "adventureBoss" GraphQL query

### DIFF
--- a/Mimir.Models/AdventureBoss/SeasonInfo.cs
+++ b/Mimir.Models/AdventureBoss/SeasonInfo.cs
@@ -1,0 +1,23 @@
+using Libplanet.Crypto;
+
+namespace Mimir.Models.AdventureBoss;
+
+public record SeasonInfo(
+    Address Address,
+    long Season,
+    long StartBlockIndex,
+    long EndBlockIndex,
+    long NextStartBlockIndex,
+    int BossId)
+{
+    public SeasonInfo(Address address, Nekoyume.Model.AdventureBoss.SeasonInfo seasonInfo) :
+        this(
+            address,
+            seasonInfo.Season,
+            seasonInfo.StartBlockIndex,
+            seasonInfo.EndBlockIndex,
+            seasonInfo.NextStartBlockIndex,
+            seasonInfo.BossId)
+    {
+    }
+}

--- a/Mimir.Worker.Tests/Handler/AdventureBoss/SeasonInfoHandlerTests.cs
+++ b/Mimir.Worker.Tests/Handler/AdventureBoss/SeasonInfoHandlerTests.cs
@@ -48,6 +48,7 @@ public class SeasonInfoHandlerTests
         endBlockIndex ??= startBlockIndex + activeInterval;
         nextStartBlockIndex ??= endBlockIndex.Value + inactiveInterval;
         bossId ??= default;
+        Assert.Equal(address, obj.Address);
         Assert.Equal(season, obj.Season);
         Assert.Equal(startBlockIndex, obj.StartBlockIndex);
         Assert.Equal(endBlockIndex.Value, obj.EndBlockIndex);

--- a/Mimir.Worker/Handler/AdventureBoss/SeasonInfoHandler.cs
+++ b/Mimir.Worker/Handler/AdventureBoss/SeasonInfoHandler.cs
@@ -1,20 +1,21 @@
 using Bencodex.Types;
+using Libplanet.Crypto;
+using Mimir.Models.AdventureBoss;
 using Mimir.Worker.Models;
 using Mimir.Worker.Models.State.AdventureBoss;
 using Mimir.Worker.Services;
-using Nekoyume.Model.AdventureBoss;
 
 namespace Mimir.Worker.Handler.AdventureBoss;
 
 public class SeasonInfoHandler : IStateHandler<StateData>
 {
     public StateData ConvertToStateData(StateDiffContext context) =>
-        new(context.Address, ConvertToState(context.RawState));
+        new(context.Address, ConvertToState(context.Address, context.RawState));
 
     public async Task StoreStateData(MongoDbService store, StateData stateData) =>
         await store.UpsertStateDataAsyncWithLinkAvatar(stateData);
 
-    private static SeasonInfoState ConvertToState(IValue state)
+    private static SeasonInfoState ConvertToState(Address address, IValue state)
     {
         if (state is not List list)
         {
@@ -23,7 +24,7 @@ public class SeasonInfoHandler : IStateHandler<StateData>
             );
         }
 
-        var seasonInfo = new SeasonInfo(list);
-        return new SeasonInfoState(seasonInfo);
+        var seasonInfo = new Nekoyume.Model.AdventureBoss.SeasonInfo(list);
+        return new SeasonInfoState(new SeasonInfo(address, seasonInfo), seasonInfo.Bencoded);
     }
 }

--- a/Mimir.Worker/Models/State/AdventureBoss/SeasonInfoState.cs
+++ b/Mimir.Worker/Models/State/AdventureBoss/SeasonInfoState.cs
@@ -1,10 +1,7 @@
 using Bencodex;
 using Bencodex.Types;
-using Nekoyume.Model.AdventureBoss;
+using Mimir.Models.AdventureBoss;
 
 namespace Mimir.Worker.Models.State.AdventureBoss;
 
-public record SeasonInfoState(SeasonInfo Object) : IBencodable
-{
-    public IValue Bencoded => Object.Bencoded;
-}
+public record SeasonInfoState(SeasonInfo Object, IValue Bencoded) : IBencodable;

--- a/Mimir/GraphQL/Objects/AdventureBossObject.cs
+++ b/Mimir/GraphQL/Objects/AdventureBossObject.cs
@@ -1,0 +1,5 @@
+namespace Mimir.GraphQL.Objects;
+
+public class AdventureBossObject
+{
+}

--- a/Mimir/GraphQL/Resolvers/AdventureBossResolver.cs
+++ b/Mimir/GraphQL/Resolvers/AdventureBossResolver.cs
@@ -1,0 +1,23 @@
+using HotChocolate.Resolvers;
+using Mimir.Models.AdventureBoss;
+using Mimir.Repositories.AdventureBoss;
+
+namespace Mimir.GraphQL.Resolvers;
+
+public class AdventureBossResolver
+{
+    public static SeasonInfo GetSeasonInfoAsync(
+        IResolverContext context,
+        [Service] SeasonInfoRepository seasonInfoRepository,
+        [ScopedState("seasonInfo")] SeasonInfo? seasonInfo)
+    {
+        if (seasonInfo is not null)
+        {
+            return seasonInfo;
+        }
+
+        seasonInfo = seasonInfoRepository.GetSeasonInfo();
+        context.ScopedContextData = context.ScopedContextData.Add("seasonInfo", seasonInfo);
+        return seasonInfo;
+    }
+}

--- a/Mimir/GraphQL/Types/AdventureBoss/SeasonInfoType.cs
+++ b/Mimir/GraphQL/Types/AdventureBoss/SeasonInfoType.cs
@@ -1,0 +1,14 @@
+using Lib9c.GraphQL.Types;
+using Mimir.Models.AdventureBoss;
+
+namespace Mimir.GraphQL.Types.AdventureBoss;
+
+public class SeasonInfoType : ObjectType<SeasonInfo>
+{
+    protected override void Configure(IObjectTypeDescriptor<SeasonInfo> descriptor)
+    {
+        descriptor
+            .Field(f => f.Address)
+            .Type<AddressType>();
+    }
+}

--- a/Mimir/GraphQL/Types/AdventureBossType.cs
+++ b/Mimir/GraphQL/Types/AdventureBossType.cs
@@ -9,7 +9,7 @@ public class AdventureBossType : ObjectType<AdventureBossObject>
     protected override void Configure(IObjectTypeDescriptor<AdventureBossObject> descriptor)
     {
         descriptor
-            .Field("seasonInfo")
+            .Field("season")
             .Description("The season of the adventure boss")
             .Type<SeasonInfoType>()
             .ResolveWith<AdventureBossResolver>(_ =>

--- a/Mimir/GraphQL/Types/AdventureBossType.cs
+++ b/Mimir/GraphQL/Types/AdventureBossType.cs
@@ -1,0 +1,18 @@
+using Mimir.GraphQL.Objects;
+using Mimir.GraphQL.Resolvers;
+using Mimir.GraphQL.Types.AdventureBoss;
+
+namespace Mimir.GraphQL.Types;
+
+public class AdventureBossType : ObjectType<AdventureBossObject>
+{
+    protected override void Configure(IObjectTypeDescriptor<AdventureBossObject> descriptor)
+    {
+        descriptor
+            .Field("seasonInfo")
+            .Description("The season of the adventure boss")
+            .Type<SeasonInfoType>()
+            .ResolveWith<AdventureBossResolver>(_ =>
+                AdventureBossResolver.GetSeasonInfoAsync(default!, default!, default!));
+    }
+}

--- a/Mimir/GraphQL/Types/QueryType.cs
+++ b/Mimir/GraphQL/Types/QueryType.cs
@@ -57,5 +57,10 @@ public class QueryType : ObjectType<Query>
 
                 return repository.GetLatestBlockIndex(context.ArgumentValue<string>("pollerType"));
             });
+
+        descriptor
+            .Field("adventureBoss")
+            .Type<AdventureBossType>()
+            .Resolve(_ => new AdventureBossObject());
     }
 }

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -8,6 +8,7 @@ using Mimir.GraphQL;
 using Mimir.Services;
 using Mimir.Options;
 using Mimir.Repositories;
+using Mimir.Repositories.AdventureBoss;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -40,6 +41,7 @@ builder.Services.AddSingleton<ItemSlotRepository>();
 builder.Services.AddSingleton<RuneSlotRepository>();
 builder.Services.AddSingleton<StakeRepository>();
 builder.Services.AddSingleton<ProductRepository>();
+builder.Services.AddSingleton<SeasonInfoRepository>();
 builder.Services.AddControllers();
 builder.Services.AddHeadlessGQLClient()
     .ConfigureHttpClient((provider, client) =>

--- a/Mimir/Repositories/AdventureBoss/SeasonInfoRepository.cs
+++ b/Mimir/Repositories/AdventureBoss/SeasonInfoRepository.cs
@@ -1,0 +1,44 @@
+using Libplanet.Crypto;
+using Mimir.Exceptions;
+using Mimir.GraphQL.Extensions;
+using Mimir.Models.AdventureBoss;
+using Mimir.Services;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Nekoyume.Module;
+
+namespace Mimir.Repositories.AdventureBoss;
+
+public class SeasonInfoRepository(MongoDbService dbService)
+{
+    public SeasonInfo GetSeasonInfo()
+    {
+        var collection = dbService.GetCollection<BsonDocument>("adventure_boss_season_info");
+        var filter = Builders<BsonDocument>.Filter.Eq("Address", AdventureBossModule.LatestSeasonAddress.ToHex());
+        var document = collection.Find(filter).FirstOrDefault();
+        if (document is null)
+        {
+            throw new DocumentNotFoundInMongoCollectionException(
+                collection.CollectionNamespace.CollectionName,
+                $"'Address' equals to '{AdventureBossModule.LatestSeasonAddress.ToHex()}'");
+        }
+
+        try
+        {
+            var doc = document["State"]["Object"].AsBsonDocument;
+            return new SeasonInfo(
+                new Address(doc["Address"].AsString),
+                doc["Season"].ToLong(),
+                doc["StartBlockIndex"].ToLong(),
+                doc["EndBlockIndex"].ToLong(),
+                doc["NextStartBlockIndex"].ToLong(),
+                doc["BossId"].AsInt32);
+        }
+        catch (KeyNotFoundException e)
+        {
+            throw new UnexpectedTypeOfBsonValueException(
+                "document[\"State\"][\"Object\"].AsBsonDocument",
+                e);
+        }
+    }
+}


### PR DESCRIPTION
- Relates with #222.
- Introduce `Mimir.Models.AdventureBoss.SeasonInfo`.
- Fix type of `SeasonInfoState.Object`.
- Introduce `SeaonInfoRepository`.
- Introduce `SeasonInfoType`.
- Introduce `AdventureBossType` with resolver.
- Add `adventureBoss` GraphQL query.

# Examples

```graphql
query adventureBossSeasonInfo {
  adventureBoss {
    season {
      address
      bossId
      endBlockIndex
      nextStartBlockIndex
      season
      startBlockIndex
    }
  }
}
```
```json
{
  "data": {
    "adventureBoss": {
      "season": {
        "address": "0x0000000000000000000000000000000000000000",
        "bossId": 666,
        "endBlockIndex": 10000,
        "nextStartBlockIndex": 19999,
        "season": 1,
        "startBlockIndex": 9999
      }
    }
  }
}
```