### PR TITLE
feat: apply season number to `adventureBoss > season` GraphQL query

### DIFF
--- a/Mimir/GraphQL/Resolvers/AdventureBossResolver.cs
+++ b/Mimir/GraphQL/Resolvers/AdventureBossResolver.cs
@@ -7,17 +7,7 @@ namespace Mimir.GraphQL.Resolvers;
 public class AdventureBossResolver
 {
     public static SeasonInfo GetSeasonInfoAsync(
-        IResolverContext context,
-        [Service] SeasonInfoRepository seasonInfoRepository,
-        [ScopedState("seasonInfo")] SeasonInfo? seasonInfo)
-    {
-        if (seasonInfo is not null)
-        {
-            return seasonInfo;
-        }
-
-        seasonInfo = seasonInfoRepository.GetSeasonInfo();
-        context.ScopedContextData = context.ScopedContextData.Add("seasonInfo", seasonInfo);
-        return seasonInfo;
-    }
+        long number,
+        [Service] SeasonInfoRepository seasonInfoRepository) =>
+        seasonInfoRepository.GetSeasonInfo(number);
 }

--- a/Mimir/GraphQL/Types/AdventureBossType.cs
+++ b/Mimir/GraphQL/Types/AdventureBossType.cs
@@ -11,8 +11,12 @@ public class AdventureBossType : ObjectType<AdventureBossObject>
         descriptor
             .Field("season")
             .Description("The season of the adventure boss")
+            .Argument("number", a => a
+                .Description("The number of season. 0 is latest season.")
+                .Type<LongType>()
+                .DefaultValue(0))
             .Type<SeasonInfoType>()
             .ResolveWith<AdventureBossResolver>(_ =>
-                AdventureBossResolver.GetSeasonInfoAsync(default!, default!, default!));
+                AdventureBossResolver.GetSeasonInfoAsync(default!, default!));
     }
 }

--- a/Mimir/Repositories/AdventureBoss/SeasonInfoRepository.cs
+++ b/Mimir/Repositories/AdventureBoss/SeasonInfoRepository.cs
@@ -5,22 +5,24 @@ using Mimir.Models.AdventureBoss;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;
+using Nekoyume.Helper;
 using Nekoyume.Module;
 
 namespace Mimir.Repositories.AdventureBoss;
 
 public class SeasonInfoRepository(MongoDbService dbService)
 {
-    public SeasonInfo GetSeasonInfo()
+    public SeasonInfo GetSeasonInfo(long number)
     {
+        var seasonAddress = new Address(AdventureBossHelper.GetSeasonAsAddressForm(number));
         var collection = dbService.GetCollection<BsonDocument>("adventure_boss_season_info");
-        var filter = Builders<BsonDocument>.Filter.Eq("Address", AdventureBossModule.LatestSeasonAddress.ToHex());
+        var filter = Builders<BsonDocument>.Filter.Eq("Address", seasonAddress.ToHex());
         var document = collection.Find(filter).FirstOrDefault();
         if (document is null)
         {
             throw new DocumentNotFoundInMongoCollectionException(
                 collection.CollectionNamespace.CollectionName,
-                $"'Address' equals to '{AdventureBossModule.LatestSeasonAddress.ToHex()}'");
+                $"'Address' equals to '{seasonAddress.ToHex()}'");
         }
 
         try


### PR DESCRIPTION
- Relates with #222.

# Examples

```graphql
query adventureBossSeasonInfo {
  adventureBoss {
    season(number: 0) {
      address
      bossId
      endBlockIndex
      nextStartBlockIndex
      season
      startBlockIndex
    }
  }
}
```
```json
{
  "data": {
    "adventureBoss": {
      "season": {
        "address": "0x0000000000000000000000000000000000000000",
        "bossId": 666,
        "endBlockIndex": 10000,
        "nextStartBlockIndex": 19999,
        "season": 1,
        "startBlockIndex": 9999
      }
    }
  }
}
```