### PR TITLE
refactor: use `ArenaDocument` in `ArenaRepository` directly

### DIFF
--- a/Lib9c.GraphQL/Types/BencodexIValueType.cs
+++ b/Lib9c.GraphQL/Types/BencodexIValueType.cs
@@ -1,5 +1,6 @@
 using Bencodex.Types;
 using HotChocolate.Types;
+using ValueKind = Bencodex.Types.ValueKind;
 
 namespace Lib9c.GraphQL.Types;
 
@@ -7,9 +8,8 @@ public class BencodexIValueType : ObjectType<IValue>
 {
     protected override void Configure(IObjectTypeDescriptor<IValue> descriptor)
     {
-        descriptor.BindFieldsExplicitly();
         descriptor
-            .Field(f => f.Inspect())
-            .Type<StringType>();
+            .Field(f => f.Kind)
+            .Type<NonNullType<EnumType<ValueKind>>>();
     }
 }

--- a/Mimir.MongoDB/Bson/AgentDocument.cs
+++ b/Mimir.MongoDB/Bson/AgentDocument.cs
@@ -3,4 +3,4 @@ using Libplanet.Crypto;
 namespace Mimir.MongoDB.Bson;
 
 public record AgentDocument(Address Address, Nekoyume.Model.State.AgentState Object)
-    : MimirBsonDocument(Address) { }
+    : MimirBsonDocument(Address);

--- a/Mimir.MongoDB/Bson/ArenaDocument.cs
+++ b/Mimir.MongoDB/Bson/ArenaDocument.cs
@@ -1,4 +1,6 @@
 using Libplanet.Crypto;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
 using Nekoyume.Model.Arena;
 using static Nekoyume.TableData.ArenaSheet;
 
@@ -11,4 +13,8 @@ public record ArenaDocument(
     ArenaScore ArenaScoreObject,
     RoundData RoundData,
     Address AvatarAddress
-) : MimirBsonDocument(ScoreAddress) { }
+) : MimirBsonDocument(ScoreAddress)
+{
+    [BsonExtraElements]
+    public BsonDocument? ExtraElements { get; init; }
+}

--- a/Mimir.MongoDB/Bson/AvatarDocument.cs
+++ b/Mimir.MongoDB/Bson/AvatarDocument.cs
@@ -3,4 +3,4 @@ using Libplanet.Crypto;
 
 namespace Mimir.MongoDB.Bson;
 
-public record AvatarDocument(Address Address, AvatarState Object) : MimirBsonDocument(Address) { }
+public record AvatarDocument(Address Address, AvatarState Object) : MimirBsonDocument(Address);

--- a/Mimir.MongoDB/Bson/Extensions/BsonValueExtensions.cs
+++ b/Mimir.MongoDB/Bson/Extensions/BsonValueExtensions.cs
@@ -1,7 +1,7 @@
-using Mimir.Exceptions;
+using Mimir.MongoDB.Exceptions;
 using MongoDB.Bson;
 
-namespace Mimir.GraphQL.Extensions;
+namespace Mimir.MongoDB.Bson.Extensions;
 
 public static class BsonValueExtensions
 {

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/AddressBsonSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/AddressBsonSerializer.cs
@@ -1,4 +1,5 @@
 using Libplanet.Crypto;
+using Mimir.MongoDB.Exceptions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
@@ -10,8 +11,13 @@ public class AddressBsonSerializer : SerializerBase<Address>
     public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Address value) =>
         context.Writer.WriteString(value.ToHex());
 
-    public override Address Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args) =>
-        context.Reader.GetCurrentBsonType() is BsonType.String
+    public override Address Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        var bsonType = context.Reader.GetCurrentBsonType();
+        return bsonType is BsonType.String
             ? new Address(context.Reader.ReadString())
-            : throw new Exception();
+            : throw new UnexpectedTypeOfBsonValueException(
+                [BsonType.String],
+                bsonType);
+    }
 }

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/AddressBsonSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/AddressBsonSerializer.cs
@@ -1,0 +1,17 @@
+using Libplanet.Crypto;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Mimir.MongoDB.Bson.Serialization.Serializers;
+
+public class AddressBsonSerializer : SerializerBase<Address>
+{
+    public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Address value) =>
+        context.Writer.WriteString(value.ToHex());
+
+    public override Address Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args) =>
+        context.Reader.GetCurrentBsonType() is BsonType.String
+            ? new Address(context.Reader.ReadString())
+            : throw new Exception();
+}

--- a/Mimir.MongoDB/Bson/WorldInformationDocument.cs
+++ b/Mimir.MongoDB/Bson/WorldInformationDocument.cs
@@ -5,12 +5,12 @@ using Nekoyume.Model.State;
 
 namespace Mimir.MongoDB.Bson;
 
-public record WorldInformationDocument(Address Address) : MimirBsonDocument(Address)
+public record WorldInformationDocument : MimirBsonDocument
 {
     public IDictionary<int, WorldInformation.World> Object { get; init; }
 
     public WorldInformationDocument(Address Address, WorldInformation worldInformation)
-        : this(Address)
+        : base(Address)
     {
         Object = ((Dictionary)worldInformation.Serialize()).ToDictionary(
             kv => kv.Key.ToInteger(),

--- a/Mimir.MongoDB/Exceptions/IDefaultMessageException.cs
+++ b/Mimir.MongoDB/Exceptions/IDefaultMessageException.cs
@@ -1,4 +1,4 @@
-namespace Mimir.Exceptions;
+namespace Mimir.MongoDB.Exceptions;
 
 public interface IDefaultMessageException
 {

--- a/Mimir.MongoDB/Exceptions/KeyNotFoundInBsonDocumentException.cs
+++ b/Mimir.MongoDB/Exceptions/KeyNotFoundInBsonDocumentException.cs
@@ -1,4 +1,4 @@
-namespace Mimir.Exceptions;
+namespace Mimir.MongoDB.Exceptions;
 
 public class KeyNotFoundInBsonDocumentException : Exception, IDefaultMessageException
 {

--- a/Mimir.MongoDB/Exceptions/UnexpectedTypeOfBsonValueException.cs
+++ b/Mimir.MongoDB/Exceptions/UnexpectedTypeOfBsonValueException.cs
@@ -1,6 +1,6 @@
 using MongoDB.Bson;
 
-namespace Mimir.Exceptions;
+namespace Mimir.MongoDB.Exceptions;
 
 public class UnexpectedTypeOfBsonValueException : Exception, IDefaultMessageException
 {

--- a/Mimir.MongoDB/Mimir.MongoDB.csproj
+++ b/Mimir.MongoDB/Mimir.MongoDB.csproj
@@ -12,6 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include="..\Lib9c.GraphQL\Lib9c.GraphQL.csproj" />
         <ProjectReference Include="..\Lib9c.Models\Lib9c.Models.csproj"/>
     </ItemGroup>
 

--- a/Mimir.Worker/Services/MongoDbService.cs
+++ b/Mimir.Worker/Services/MongoDbService.cs
@@ -2,8 +2,10 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Bencodex;
 using Mimir.MongoDB.Bson;
+using Mimir.MongoDB.Bson.Serialization.Serializers;
 using Mimir.Worker.Constants;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
 using Nekoyume;
@@ -30,6 +32,8 @@ public class MongoDbService
 
     public MongoDbService(string connectionString, PlanetType planetType, string? pathToCAFile)
     {
+        BsonSerializer.RegisterSerializer(new AddressBsonSerializer());
+
         var settings = MongoClientSettings.FromUrl(new MongoUrl(connectionString));
 
         if (pathToCAFile is not null)

--- a/Mimir/Controllers/ArenaController.cs
+++ b/Mimir/Controllers/ArenaController.cs
@@ -23,10 +23,10 @@ public class ArenaController(
     [HttpGet("season")]
     public ArenaSeason GetLatestSeason(MetadataRepository metadataRepository)
     {
-        var arenaRound = tableSheetsRepository.GetArenaRound(
-            metadataRepository.GetLatestBlockIndex("BlockPoller", CollectionNames.Arena.Value)
-        );
-
+        var latestBlockIndex = metadataRepository.GetLatestBlockIndex(
+            "TxPoller",
+            CollectionNames.Arena.Value);
+        var arenaRound = tableSheetsRepository.GetArenaRound(latestBlockIndex);
         return new ArenaSeason(arenaRound.ChampionshipId, arenaRound.Round);
     }
 

--- a/Mimir/Exceptions/DocumentNotFoundInMongoCollectionException.cs
+++ b/Mimir/Exceptions/DocumentNotFoundInMongoCollectionException.cs
@@ -1,3 +1,5 @@
+using Mimir.MongoDB.Exceptions;
+
 namespace Mimir.Exceptions;
 
 public class DocumentNotFoundInMongoCollectionException : Exception, IDefaultMessageException

--- a/Mimir/Factories/StatMapFactory.cs
+++ b/Mimir/Factories/StatMapFactory.cs
@@ -1,5 +1,4 @@
-using Mimir.Exceptions;
-using Mimir.GraphQL.Extensions;
+using Mimir.MongoDB.Bson.Extensions;
 using MongoDB.Bson;
 using Nekoyume.Model.Stat;
 

--- a/Mimir/GraphQL/ErrorFilter.cs
+++ b/Mimir/GraphQL/ErrorFilter.cs
@@ -1,4 +1,4 @@
-using Mimir.Exceptions;
+using Mimir.MongoDB.Exceptions;
 
 namespace Mimir.GraphQL;
 

--- a/Mimir/GraphQL/Factories/SkillObjectFactory.cs
+++ b/Mimir/GraphQL/Factories/SkillObjectFactory.cs
@@ -1,6 +1,6 @@
 using Bencodex.Types;
-using Mimir.GraphQL.Extensions;
 using Mimir.GraphQL.Objects;
+using Mimir.MongoDB.Bson.Extensions;
 using MongoDB.Bson;
 using Nekoyume.Model.Skill;
 using Nekoyume.Model.Stat;

--- a/Mimir/GraphQL/Resolvers/ArenaResolver.cs
+++ b/Mimir/GraphQL/Resolvers/ArenaResolver.cs
@@ -20,7 +20,9 @@ public class ArenaResolver
             return arenaRound;
         }
 
-        var latestBlockIndex = metadataRepo.GetLatestBlockIndex("BlockPoller", CollectionNames.Arena.Value);
+        var latestBlockIndex = metadataRepo.GetLatestBlockIndex(
+            "TxPoller",
+            CollectionNames.Arena.Value);
         arenaRound = tableSheetsRepo.GetArenaRound(latestBlockIndex);
         context.ScopedContextData = context.ScopedContextData.Add("arenaRound", arenaRound);
         return arenaRound;

--- a/Mimir/Models/Arena/ArenaRanking.cs
+++ b/Mimir/Models/Arena/ArenaRanking.cs
@@ -2,30 +2,20 @@ using System.Text.Json.Serialization;
 
 namespace Mimir.Models.Arena;
 
-public class ArenaRanking(
-    string avatarAddress,
-    string arenaAddress,
-    int win,
-    int lose,
-    long rank,
-    int ticket,
-    int ticketResetCount,
-    int purchasedTicketCount,
-    int score
-)
+public record ArenaRanking(
+    string AvatarAddress,
+    string ArenaAddress,
+    int Win,
+    int Lose,
+    long Rank,
+    int Ticket,
+    int TicketResetCount,
+    int PurchasedTicketCount,
+    int Score)
 {
-    public string AvatarAddress { get; set; } = avatarAddress;
-    public string ArenaAddress { get; set; } = arenaAddress;
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? CP { get; set; }
-    public int Win { get; set; } = win;
-    public int Lose { get; set; } = lose;
-    public long Rank { get; set; } = rank;
-    public int Ticket { get; set; } = ticket;
-    public int TicketResetCount { get; set; } = ticketResetCount;
-    public int PurchasedTicketCount { get; set; } = purchasedTicketCount;
-    public int Score { get; set; } = score;
-
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public Avatar? Avatar { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? CP { get; set; }
 }

--- a/Mimir/Models/Arena/ArenaRanking.cs
+++ b/Mimir/Models/Arena/ArenaRanking.cs
@@ -3,8 +3,8 @@ using System.Text.Json.Serialization;
 namespace Mimir.Models.Arena;
 
 public record ArenaRanking(
-    string AvatarAddress,
-    string ArenaAddress,
+    string AvatarAddress, // FIXME: to Address type
+    string ArenaAddress, // FIXME: to Address type
     int Win,
     int Lose,
     long Rank,

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -2,13 +2,14 @@ using System.Text.Json.Serialization;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http.Headers;
 using System.Text;
+using Lib9c.GraphQL.Types;
+using Libplanet.Crypto;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Extensions.Options;
 using Mimir.GraphQL;
 using Mimir.Services;
 using Mimir.Options;
 using Mimir.Repositories;
-using Mimir.Repositories.AdventureBoss;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -71,6 +72,7 @@ builder.Services
     .AddGraphQLServer()
     .AddLib9cGraphQLTypes()
     .AddMimirGraphQLTypes()
+    .BindRuntimeType(typeof(Address), typeof(AddressType))
     .AddErrorFilter<ErrorFilter>()
     .ModifyRequestOptions(requestExecutorOptions =>
     {

--- a/Mimir/Repositories/ActionPointRepository.cs
+++ b/Mimir/Repositories/ActionPointRepository.cs
@@ -1,6 +1,7 @@
 using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/AdventureBoss/SeasonInfoRepository.cs
+++ b/Mimir/Repositories/AdventureBoss/SeasonInfoRepository.cs
@@ -1,7 +1,8 @@
 using Libplanet.Crypto;
 using Lib9c.Models.AdventureBoss;
 using Mimir.Exceptions;
-using Mimir.GraphQL.Extensions;
+using Mimir.MongoDB.Bson.Extensions;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/AgentRepository.cs
+++ b/Mimir/Repositories/AgentRepository.cs
@@ -2,6 +2,7 @@ using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
 using Mimir.Models;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/AllRuneRepository.cs
+++ b/Mimir/Repositories/AllRuneRepository.cs
@@ -2,6 +2,7 @@ using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
 using Mimir.Models.Assets;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/ArenaRepository.cs
+++ b/Mimir/Repositories/ArenaRepository.cs
@@ -154,14 +154,14 @@ public class ArenaRepository(MongoDbService dbService, IStateService stateServic
                 document.AvatarAddress);
             arenaRanking.Avatar = avatar;
 
-            // Set CP
-            var runeSlotState = await _stateGetter.GetArenaRuneSlotStateAsync(
-                document.AvatarAddress);
-            var cp = await _cpRepository.CalculateCp(
-                avatar,
-                runeSlotState);
-            arenaRanking.CP = cp;
-            Console.WriteLine($"CP Calculate {arenaRanking.ArenaAddress}");
+            // NOTE: Uncomment if the CP needed.
+            // // Set CP
+            // var runeSlotState = await _stateGetter.GetArenaRuneSlotStateAsync(
+            //     document.AvatarAddress);
+            // var cp = await _cpRepository.CalculateCp(
+            //     avatar,
+            //     runeSlotState);
+            // arenaRanking.CP = cp;
         }
         catch (DocumentNotFoundInMongoCollectionException e)
         {

--- a/Mimir/Repositories/ArenaRepository.cs
+++ b/Mimir/Repositories/ArenaRepository.cs
@@ -85,8 +85,8 @@ public class ArenaRepository(MongoDbService dbService, IStateService stateServic
         IMongoCollection<BsonDocument> collection,
         long skip,
         int limit,
-        int? championshipId,
-        int? round)
+        int championshipId,
+        int round)
     {
         var pipelines = new List<BsonDocument>
         {

--- a/Mimir/Repositories/ArenaRepository.cs
+++ b/Mimir/Repositories/ArenaRepository.cs
@@ -118,27 +118,26 @@ public class ArenaRepository(MongoDbService dbService, IStateService stateServic
             new("$limit", limit)
         };
 
-        var aggregation = collection.Aggregate<BsonDocument>(pipelines).ToList();
         var arenaRankings = await Task.WhenAll(
             aggregation.Where(e => e is not null).Select(BuildArenaRankingFromDocument));
         return arenaRankings.Where(e => e is not null).ToList()!;
+        var aggregation = collection
+            .Aggregate<ArenaDocument>(pipelines)
+            .ToList();
     }
 
-    private async Task<ArenaRanking?> BuildArenaRankingFromDocument(BsonDocument document)
+    private async Task<ArenaRanking?> BuildArenaRankingFromDocument(ArenaDocument document)
     {
-        var avatarAddress = document["AvatarAddress"].AsString;
-
         var arenaRanking = new ArenaRanking(
-            document["AvatarAddress"].AsString,
-            document["ArenaInformationObject"]["Address"].AsString,
-            document["ArenaInformationObject"]["Win"].ToInt32(),
-            document["ArenaInformationObject"]["Lose"].ToInt32(),
-            document["Rank"].ToInt64() + 1,
-            document["ArenaInformationObject"]["Ticket"].ToInt32(),
-            document["ArenaInformationObject"]["TicketResetCount"].ToInt32(),
-            document["ArenaInformationObject"]["PurchasedTicketCount"].ToInt32(),
-            document["ArenaScoreObject"]["Score"].ToInt32()
-        );
+            document.AvatarAddress.ToHex(),
+            document.ArenaInformationObject.Address.ToHex(),
+            document.ArenaInformationObject.Win,
+            document.ArenaInformationObject.Lose,
+            document.ExtraElements?["Rank"].ToInt64() + 1 ?? 0,
+            document.ArenaInformationObject.Ticket,
+            document.ArenaInformationObject.TicketResetCount,
+            document.ArenaInformationObject.PurchasedTicketCount,
+            document.ArenaScoreObject.Score);
 
         try
         {

--- a/Mimir/Repositories/ArenaRepository.cs
+++ b/Mimir/Repositories/ArenaRepository.cs
@@ -1,4 +1,3 @@
-using Bencodex;
 using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
@@ -12,9 +11,8 @@ namespace Mimir.Repositories;
 
 public class ArenaRepository(MongoDbService dbService, IStateService stateService)
 {
-    private static readonly Codec Codec = new();
     private readonly CpRepository _cpRepository = new(stateService);
-    private StateGetter _stateGetter = new(stateService);
+    private readonly StateGetter _stateGetter = new(stateService);
 
     public async Task<long> GetRankingByAvatarAddressAsync(
         Address avatarAddress,

--- a/Mimir/Repositories/AvatarRepository.cs
+++ b/Mimir/Repositories/AvatarRepository.cs
@@ -2,6 +2,7 @@ using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
 using Mimir.Models;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/CollectionRepository.cs
+++ b/Mimir/Repositories/CollectionRepository.cs
@@ -2,6 +2,7 @@ using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
 using Mimir.Models.Assets;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/DailyRewardRepository.cs
+++ b/Mimir/Repositories/DailyRewardRepository.cs
@@ -1,7 +1,8 @@
 using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
-using Mimir.GraphQL.Extensions;
+using Mimir.MongoDB.Bson.Extensions;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/InventoryRepository.cs
+++ b/Mimir/Repositories/InventoryRepository.cs
@@ -2,6 +2,7 @@ using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
 using Mimir.Models;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/ItemSlotRepository.cs
+++ b/Mimir/Repositories/ItemSlotRepository.cs
@@ -1,6 +1,7 @@
 using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/RuneSlotRepository.cs
+++ b/Mimir/Repositories/RuneSlotRepository.cs
@@ -2,6 +2,7 @@ using Libplanet.Crypto;
 using Lib9c.Models.Runes;
 using Mimir.Enums;
 using Mimir.Exceptions;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/StakeRepository.cs
+++ b/Mimir/Repositories/StakeRepository.cs
@@ -1,7 +1,8 @@
 using Libplanet.Crypto;
 using Mimir.Enums;
 using Mimir.Exceptions;
-using Mimir.GraphQL.Extensions;
+using Mimir.MongoDB.Bson.Extensions;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/Mimir/Repositories/TableSheetsRepository.cs
+++ b/Mimir/Repositories/TableSheetsRepository.cs
@@ -1,15 +1,13 @@
-using System.Text;
 using Bencodex;
 using Bencodex.Types;
 using Mimir.Enums;
-using Mimir.Exceptions;
-using Mimir.GraphQL.Extensions;
+using Mimir.MongoDB.Bson.Extensions;
+using Mimir.MongoDB.Exceptions;
 using Mimir.Services;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
-using Nekoyume;
 using Nekoyume.Action;
 using Nekoyume.Model.EnumType;
 using Nekoyume.TableData;

--- a/Mimir/Services/MongoDbService.cs
+++ b/Mimir/Services/MongoDbService.cs
@@ -1,7 +1,9 @@
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Options;
+using Mimir.MongoDB.Bson.Serialization.Serializers;
 using Mimir.Options;
 using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
 
@@ -14,6 +16,7 @@ public class MongoDbService
 
     public MongoDbService(IOptions<DatabaseOption> databaseOption)
     {
+        BsonSerializer.RegisterSerializer(new AddressBsonSerializer());
         var settings = MongoClientSettings.FromUrl(
             new MongoUrl(databaseOption.Value.ConnectionString)
         );


### PR DESCRIPTION
- Add `ExtraElements` to `ArenaDocument` for pipeline work.
- Use `ArenaDocument` in `ArenaRepository` directly.
- Refactor `ArenaRanking` to record.
- Introduce `AddressBsonSerializer`.
- Fix runtime type for `Address`.
