### PR TITLE
Integrate `AvatarDocument` MongoDB model with GraphQL schema

### DIFF
--- a/Lib9c.Models/Mails/Mail.cs
+++ b/Lib9c.Models/Mails/Mail.cs
@@ -1,11 +1,13 @@
 using Bencodex;
 using Bencodex.Types;
 using Lib9c.Models.Exceptions;
+using MongoDB.Bson.Serialization.Attributes;
 using Nekoyume.Model.State;
 using ValueKind = Bencodex.Types.ValueKind;
 
 namespace Lib9c.Models.Mails;
 
+[BsonIgnoreExtraElements]
 public record Mail : IBencodable
 {
     public Guid Id { get; init; }

--- a/Lib9c.Models/States/AgentState.cs
+++ b/Lib9c.Models/States/AgentState.cs
@@ -1,11 +1,16 @@
 using Bencodex.Types;
 using Lib9c.Models.Exceptions;
 using Libplanet.Crypto;
+using MongoDB.Bson.Serialization.Attributes;
 using Nekoyume.Model.State;
 using ValueKind = Bencodex.Types.ValueKind;
 
 namespace Lib9c.Models.States;
 
+/// <summary>
+/// <see cref="Nekoyume.Model.State.AgentState"/>
+/// </summary>
+[BsonIgnoreExtraElements]
 public record AgentState : State
 {
     public Dictionary<int, Address> AvatarAddresses { get; init; }
@@ -14,6 +19,7 @@ public record AgentState : State
 
     public int Version { get; init; }
 
+    [BsonIgnore, GraphQLIgnore]
     public override IValue Bencoded => new List(
         base.Bencoded,
         (Integer)1,

--- a/Lib9c.Models/States/AvatarState.cs
+++ b/Lib9c.Models/States/AvatarState.cs
@@ -2,6 +2,7 @@ using Bencodex.Types;
 using Lib9c.Models.Exceptions;
 using Lib9c.Models.Mails;
 using Libplanet.Crypto;
+using MongoDB.Bson.Serialization.Attributes;
 using Nekoyume.Model;
 using Nekoyume.Model.State;
 using ValueKind = Bencodex.Types.ValueKind;
@@ -11,6 +12,7 @@ namespace Lib9c.Models.States;
 /// <summary>
 /// <see cref="Nekoyume.Model.State.AvatarState"/>
 /// </summary>
+[BsonIgnoreExtraElements]
 public record AvatarState : State
 {
     public int Version { get; init; }
@@ -35,6 +37,7 @@ public record AvatarState : State
     public List<Address> CombinationSlotAddresses { get; init; }
     public Address RankingMapAddress { get; init; }
 
+    [BsonIgnore, GraphQLIgnore]
     public override IValue Bencoded => new List(
         base.Bencoded,
         (Integer)Version,

--- a/Mimir.MongoDB/Bson/AvatarDocument.cs
+++ b/Mimir.MongoDB/Bson/AvatarDocument.cs
@@ -1,6 +1,8 @@
 using Lib9c.Models.States;
 using Libplanet.Crypto;
+using MongoDB.Bson.Serialization.Attributes;
 
 namespace Mimir.MongoDB.Bson;
 
+[BsonIgnoreExtraElements]
 public record AvatarDocument(Address Address, AvatarState Object) : MimirBsonDocument(Address);

--- a/Mimir.MongoDB/Bson/Serialization/SerializationRegistry.cs
+++ b/Mimir.MongoDB/Bson/Serialization/SerializationRegistry.cs
@@ -1,5 +1,8 @@
+using System.Numerics;
 using Libplanet.Crypto;
+using Libplanet.Types.Assets;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
+using Mimir.MongoDB.Bson.Serialization.Serializers.System;
 using MongoDB.Bson.Serialization;
 
 namespace Mimir.MongoDB.Bson.Serialization;
@@ -8,7 +11,12 @@ public static class SerializationRegistry
 {
     public static void Register()
     {
+        // System
+        BsonSerializer.RegisterSerializer(typeof(BigInteger), BigIntegerSerializer.Instance);
+
         // Libplanet
-        BsonSerializer.RegisterSerializer(typeof(Address), new AddressSerializer());
+        BsonSerializer.RegisterSerializer(typeof(Address), AddressSerializer.Instance);
+        BsonSerializer.RegisterSerializer(typeof(Currency), CurrencySerializer.Instance);
+        BsonSerializer.RegisterSerializer(typeof(FungibleAssetValue), FungibleAssetValueSerializer.Instance);
     }
 }

--- a/Mimir.MongoDB/Bson/Serialization/SerializationRegistry.cs
+++ b/Mimir.MongoDB/Bson/Serialization/SerializationRegistry.cs
@@ -1,5 +1,5 @@
 using Libplanet.Crypto;
-using Mimir.MongoDB.Bson.Serialization.Serializers;
+using Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
 using MongoDB.Bson.Serialization;
 
 namespace Mimir.MongoDB.Bson.Serialization;
@@ -8,6 +8,7 @@ public static class SerializationRegistry
 {
     public static void Register()
     {
-        BsonSerializer.RegisterSerializer(typeof(Address), new LibplanetCryptoAddressBsonSerializer());
+        // Libplanet
+        BsonSerializer.RegisterSerializer(typeof(Address), new AddressSerializer());
     }
 }

--- a/Mimir.MongoDB/Bson/Serialization/SerializationRegistry.cs
+++ b/Mimir.MongoDB/Bson/Serialization/SerializationRegistry.cs
@@ -1,0 +1,13 @@
+using Libplanet.Crypto;
+using Mimir.MongoDB.Bson.Serialization.Serializers;
+using MongoDB.Bson.Serialization;
+
+namespace Mimir.MongoDB.Bson.Serialization;
+
+public static class SerializationRegistry
+{
+    public static void Register()
+    {
+        BsonSerializer.RegisterSerializer(typeof(Address), new LibplanetCryptoAddressBsonSerializer());
+    }
+}

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Libplanet/AddressSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Libplanet/AddressSerializer.cs
@@ -8,16 +8,22 @@ namespace Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
 
 public class AddressSerializer : StructSerializerBase<Address>
 {
-    public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Address value) =>
+    public static readonly AddressSerializer Instance = new();
+
+    public override void Serialize(
+        BsonSerializationContext context,
+        BsonSerializationArgs args,
+        Address value) =>
         context.Writer.WriteString(value.ToHex());
 
-    public override Address Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    public override Address Deserialize(
+        BsonDeserializationContext context,
+        BsonDeserializationArgs args)
     {
-        var bsonType = context.Reader.GetCurrentBsonType();
+        var reader = context.Reader;
+        var bsonType = reader.GetCurrentBsonType();
         return bsonType is BsonType.String
-            ? new Address(context.Reader.ReadString())
-            : throw new UnexpectedTypeOfBsonValueException(
-                [BsonType.String],
-                bsonType);
+            ? new Address(reader.ReadString())
+            : throw new UnexpectedTypeOfBsonValueException([BsonType.String], bsonType);
     }
 }

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Libplanet/AddressSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Libplanet/AddressSerializer.cs
@@ -4,9 +4,9 @@ using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
 
-namespace Mimir.MongoDB.Bson.Serialization.Serializers;
+namespace Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
 
-public class LibplanetCryptoAddressBsonSerializer : SerializerBase<Address>
+public class AddressSerializer : StructSerializerBase<Address>
 {
     public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Address value) =>
         context.Writer.WriteString(value.ToHex());

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Libplanet/CurrencySerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Libplanet/CurrencySerializer.cs
@@ -1,0 +1,124 @@
+using System.Collections.Immutable;
+using System.Numerics;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using Mimir.MongoDB.Bson.Serialization.Serializers.System;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
+
+public class CurrencySerializer : StructSerializerBase<Currency>
+{
+    private static class ElementNames
+    {
+        public const string Ticker = "Ticker";
+        public const string DecimalPlaces = "DecimalPlaces";
+        public const string Minters = "Minters";
+        public const string TotalSupplyTrackable = "TotalSupplyTrackable";
+        public const string MaximumSupply = "MaximumSupply";
+    }
+
+    private static class Flags
+    {
+        public const long Ticker = 1L << 0;
+        public const long DecimalPlaces = 1L << 1;
+        public const long Minters = 1L << 2;
+        public const long TotalSupplyTrackable = 1L << 3;
+        public const long MaximumSupply = 1L << 4;
+    }
+
+    public static readonly CurrencySerializer Instance = new();
+
+    private readonly SerializerHelper _helper = new(
+        new SerializerHelper.Member(ElementNames.Ticker, Flags.Ticker),
+        new SerializerHelper.Member(ElementNames.DecimalPlaces, Flags.DecimalPlaces),
+        new SerializerHelper.Member(ElementNames.Minters, Flags.Minters),
+        new SerializerHelper.Member(ElementNames.TotalSupplyTrackable, Flags.TotalSupplyTrackable),
+        new SerializerHelper.Member(ElementNames.MaximumSupply, Flags.MaximumSupply));
+
+    private readonly BsonSerializationInfo _decimalPlacesInfo = new(
+        ElementNames.DecimalPlaces,
+        new ByteSerializer(),
+        typeof(byte));
+
+    private readonly BsonSerializationInfo _mintersInfo = new(
+        ElementNames.Minters,
+        new ArraySerializer<AddressSerializer>(),
+        typeof(IImmutableSet<Address>));
+
+    private readonly BsonSerializationInfo _maximumSupplyInfo = new(
+        ElementNames.MaximumSupply,
+        new NullableSerializer<(BigInteger, BigInteger)>(
+            new ValueTupleSerializer<BigInteger, BigInteger>(
+                BigIntegerSerializer.Instance,
+                BigIntegerSerializer.Instance)),
+        typeof((BigInteger, BigInteger)?));
+
+    public override void Serialize(
+        BsonSerializationContext context,
+        BsonSerializationArgs args,
+        Currency value)
+    {
+        var writer = context.Writer;
+        writer.WriteStartDocument();
+        writer.WriteName(ElementNames.Ticker);
+        writer.WriteString(value.Ticker);
+        writer.WriteName(ElementNames.DecimalPlaces);
+        _decimalPlacesInfo.Serializer.Serialize(context, value.DecimalPlaces);
+        writer.WriteName(ElementNames.Minters);
+        _mintersInfo.Serializer.Serialize(context, value.Minters);
+        writer.WriteName(ElementNames.TotalSupplyTrackable);
+        writer.WriteBoolean(value.TotalSupplyTrackable);
+        writer.WriteName(ElementNames.MaximumSupply);
+        _maximumSupplyInfo.Serializer.Serialize(context, value.MaximumSupply);
+        writer.WriteEndDocument();
+    }
+
+    public override Currency Deserialize(
+        BsonDeserializationContext context,
+        BsonDeserializationArgs args)
+    {
+        var ticker = string.Empty;
+        byte decimalPlaces = default;
+        Address[]? minters = null;
+        bool totalSupplyTrackable = default;
+        (BigInteger majorUnit, BigInteger minorUnit)? maximumSupply = null;
+        _helper.DeserializeMembers(context, (_, flag) =>
+        {
+            switch (flag)
+            {
+                case Flags.Ticker:
+                    ticker = context.Reader.ReadString();
+                    break;
+                case Flags.DecimalPlaces:
+                    decimalPlaces = (byte)_decimalPlacesInfo.Serializer.Deserialize(context);
+                    break;
+                case Flags.Minters:
+                    minters = (Address[]?)_mintersInfo.Serializer.Deserialize(context);
+                    break;
+                case Flags.TotalSupplyTrackable:
+                    totalSupplyTrackable = context.Reader.ReadBoolean();
+                    break;
+                case Flags.MaximumSupply:
+                    maximumSupply =
+                        ((BigInteger majorUnit, BigInteger minorUnit)?)_maximumSupplyInfo.Serializer
+                            .Deserialize(context);
+                    break;
+            }
+        });
+
+        if (totalSupplyTrackable)
+        {
+            return maximumSupply.HasValue
+                ? Currency.Capped(
+                    ticker,
+                    decimalPlaces,
+                    maximumSupply.Value,
+                    minters?.ToImmutableHashSet())
+                : Currency.Uncapped(ticker, decimalPlaces, minters?.ToImmutableHashSet());
+        }
+
+        return Currency.Legacy(ticker, decimalPlaces, minters?.ToImmutableHashSet());
+    }
+}

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Libplanet/FungibleAssetValueSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Libplanet/FungibleAssetValueSerializer.cs
@@ -1,0 +1,73 @@
+using System.Numerics;
+using Libplanet.Types.Assets;
+using Mimir.MongoDB.Bson.Serialization.Serializers.System;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
+
+public class FungibleAssetValueSerializer : StructSerializerBase<FungibleAssetValue>
+{
+    private static class ElementNames
+    {
+        public const string Currency = "Currency";
+        public const string RawValue = "RawValue";
+    }
+
+    private static class Flags
+    {
+        public const long Currency = 1L << 0;
+        public const long RawValue = 1L << 1;
+    }
+
+    public static readonly FungibleAssetValueSerializer Instance = new();
+
+    private readonly SerializerHelper _helper = new(
+        new SerializerHelper.Member(ElementNames.Currency, Flags.Currency),
+        new SerializerHelper.Member(ElementNames.RawValue, Flags.RawValue));
+
+    private readonly BsonSerializationInfo _currencyInfo = new(
+        ElementNames.Currency,
+        CurrencySerializer.Instance,
+        typeof(Currency));
+
+    private readonly BsonSerializationInfo _rawValueInfo = new(
+        ElementNames.RawValue,
+        BigIntegerSerializer.Instance,
+        typeof(BigInteger));
+
+    public override void Serialize(
+        BsonSerializationContext context,
+        BsonSerializationArgs args,
+        FungibleAssetValue value)
+    {
+        var writer = context.Writer;
+        writer.WriteStartDocument();
+        writer.WriteName(ElementNames.Currency);
+        _currencyInfo.Serializer.Serialize(context, value.Currency);
+        writer.WriteName(ElementNames.RawValue);
+        _rawValueInfo.Serializer.Serialize(context, value.RawValue);
+        writer.WriteEndDocument();
+    }
+
+    public override FungibleAssetValue Deserialize(
+        BsonDeserializationContext context,
+        BsonDeserializationArgs args)
+    {
+        Currency currency = default;
+        BigInteger rawValue = default;
+        _helper.DeserializeMembers(context, (_, flag) =>
+        {
+            switch (flag)
+            {
+                case Flags.Currency:
+                    currency = (Currency)_currencyInfo.Serializer.Deserialize(context);
+                    break;
+                case Flags.RawValue:
+                    rawValue = (BigInteger)_rawValueInfo.Serializer.Deserialize(context);
+                    break;
+            }
+        });
+        return FungibleAssetValue.FromRawValue(currency, rawValue);
+    }
+}

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/LibplanetCryptoAddressBsonSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/LibplanetCryptoAddressBsonSerializer.cs
@@ -6,7 +6,7 @@ using MongoDB.Bson.Serialization.Serializers;
 
 namespace Mimir.MongoDB.Bson.Serialization.Serializers;
 
-public class AddressBsonSerializer : SerializerBase<Address>
+public class LibplanetCryptoAddressBsonSerializer : SerializerBase<Address>
 {
     public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Address value) =>
         context.Writer.WriteString(value.ToHex());

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/System/BigIntegerSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/System/BigIntegerSerializer.cs
@@ -1,0 +1,29 @@
+using System.Numerics;
+using Mimir.MongoDB.Exceptions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Mimir.MongoDB.Bson.Serialization.Serializers.System;
+
+public class BigIntegerSerializer : StructSerializerBase<BigInteger>
+{
+    public static readonly BigIntegerSerializer Instance = new();
+
+    public override void Serialize(
+        BsonSerializationContext context,
+        BsonSerializationArgs args,
+        BigInteger value) =>
+        context.Writer.WriteString(value.ToString());
+
+    public override BigInteger Deserialize(
+        BsonDeserializationContext context,
+        BsonDeserializationArgs args)
+    {
+        var reader = context.Reader;
+        var bsonType = reader.GetCurrentBsonType();
+        return bsonType is BsonType.String
+            ? BigInteger.Parse(reader.ReadString())
+            : throw new UnexpectedTypeOfBsonValueException([BsonType.String], bsonType);
+    }
+}

--- a/Mimir.Worker/Handler/AvatarStateHandler.cs
+++ b/Mimir.Worker/Handler/AvatarStateHandler.cs
@@ -1,3 +1,4 @@
+using Lib9c.Models.States;
 using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
@@ -6,6 +7,6 @@ public class AvatarStateHandler : IStateHandler
 {
     public MimirBsonDocument ConvertToState(StateDiffContext context)
     {
-        return new AvatarDocument(context.Address, new Lib9c.Models.States.AvatarState(context.RawState));
+        return new AvatarDocument(context.Address, new AvatarState(context.RawState));
     }
 }

--- a/Mimir.Worker/Services/MongoDbService.cs
+++ b/Mimir.Worker/Services/MongoDbService.cs
@@ -32,7 +32,7 @@ public class MongoDbService
 
     public MongoDbService(string connectionString, PlanetType planetType, string? pathToCAFile)
     {
-        BsonSerializer.RegisterSerializer(new AddressBsonSerializer());
+        BsonSerializer.RegisterSerializer(new LibplanetCryptoAddressBsonSerializer());
 
         var settings = MongoClientSettings.FromUrl(new MongoUrl(connectionString));
 

--- a/Mimir.Worker/Services/MongoDbService.cs
+++ b/Mimir.Worker/Services/MongoDbService.cs
@@ -2,10 +2,9 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Bencodex;
 using Mimir.MongoDB.Bson;
-using Mimir.MongoDB.Bson.Serialization.Serializers;
+using Mimir.MongoDB.Bson.Serialization;
 using Mimir.Worker.Constants;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
 using Nekoyume;
@@ -32,7 +31,7 @@ public class MongoDbService
 
     public MongoDbService(string connectionString, PlanetType planetType, string? pathToCAFile)
     {
-        BsonSerializer.RegisterSerializer(new LibplanetCryptoAddressBsonSerializer());
+        SerializationRegistry.Register();
 
         var settings = MongoClientSettings.FromUrl(new MongoUrl(connectionString));
 

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -11,7 +11,7 @@ public class Query
         Address address,
         [Service] AgentRepository repo)
     {
-        var doc = await repo.GetAgentAsync(address);
+        var doc = await repo.GetByAddressAsync(address);
         return doc.Object;
     }
 

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -1,5 +1,6 @@
 using Lib9c.Models.States;
 using Libplanet.Crypto;
+using Mimir.GraphQL.Objects;
 using Mimir.Repositories;
 
 namespace Mimir.GraphQL.Queries;
@@ -13,4 +14,6 @@ public class Query
         var doc = await repo.GetAgentAsync(address);
         return doc.Object;
     }
+
+    public ArenaObject GetArena() => new();
 }

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -15,5 +15,13 @@ public class Query
         return doc.Object;
     }
 
+    public async Task<AvatarState> GetAvatarAsync(
+        Address address,
+        [Service] AvatarRepository repo)
+    {
+        var doc = await repo.GetByAddressAsync(address);
+        return doc.Object;
+    }
+
     public ArenaObject GetArena() => new();
 }

--- a/Mimir/GraphQL/Types/QueryType.cs
+++ b/Mimir/GraphQL/Types/QueryType.cs
@@ -23,11 +23,6 @@ public class QueryType : ObjectType<Query>
             .Resolve(context => new InventoryObject(context.ArgumentValue<Address>("address")));
 
         descriptor
-            .Field("arena")
-            .Type<ArenaType>()
-            .Resolve(_ => new ArenaObject());
-
-        descriptor
             .Field("product")
             .Argument("skip", a => a.Type<NonNullType<LongType>>())
             .Argument("limit", a => a.Type<NonNullType<IntType>>())

--- a/Mimir/GraphQL/Types/QueryType.cs
+++ b/Mimir/GraphQL/Types/QueryType.cs
@@ -11,12 +11,6 @@ public class QueryType : ObjectType<Query>
     protected override void Configure(IObjectTypeDescriptor<Query> descriptor)
     {
         descriptor
-            .Field("avatar")
-            .Argument("address", a => a.Type<NonNullType<AddressType>>())
-            .Type<AvatarType>()
-            .Resolve(context => new AvatarObject(context.ArgumentValue<Address>("address")));
-
-        descriptor
             .Field("inventory")
             .Argument("address", a => a.Type<NonNullType<AddressType>>())
             .Type<InventoryType>()

--- a/Mimir/Repositories/AgentRepository.cs
+++ b/Mimir/Repositories/AgentRepository.cs
@@ -9,7 +9,7 @@ namespace Mimir.Repositories;
 
 public class AgentRepository(MongoDbService dbService)
 {
-    public async Task<AgentDocument> GetAgentAsync(Address agentAddress)
+    public async Task<AgentDocument> GetByAddressAsync(Address agentAddress)
     {
         var collection = dbService.GetCollection<AgentDocument>(CollectionNames.Agent.Value);
         var filter = Builders<AgentDocument>.Filter.Eq("Address", agentAddress.ToHex());

--- a/Mimir/Repositories/AvatarRepository.cs
+++ b/Mimir/Repositories/AvatarRepository.cs
@@ -12,11 +12,11 @@ namespace Mimir.Repositories;
 
 public class AvatarRepository(MongoDbService dbService)
 {
-    public Task<AvatarDocument> GetByAddressAsync(Address address)
+    public async Task<AvatarDocument> GetByAddressAsync(Address address)
     {
         var filter = Builders<AvatarDocument>.Filter.Eq("Address", address.ToHex());
         var collection = dbService.GetCollection<AvatarDocument>(CollectionNames.Avatar.Value);
-        var document = collection.Find(filter).FirstOrDefaultAsync();
+        var document = await collection.Find(filter).FirstOrDefaultAsync();
         if (document is null)
         {
             throw new DocumentNotFoundInMongoCollectionException(

--- a/Mimir/Services/MongoDbService.cs
+++ b/Mimir/Services/MongoDbService.cs
@@ -16,7 +16,7 @@ public class MongoDbService
 
     public MongoDbService(IOptions<DatabaseOption> databaseOption)
     {
-        BsonSerializer.RegisterSerializer(new AddressBsonSerializer());
+        BsonSerializer.RegisterSerializer(new LibplanetCryptoAddressBsonSerializer());
         var settings = MongoClientSettings.FromUrl(
             new MongoUrl(databaseOption.Value.ConnectionString)
         );

--- a/Mimir/Services/MongoDbService.cs
+++ b/Mimir/Services/MongoDbService.cs
@@ -1,9 +1,8 @@
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.Options;
-using Mimir.MongoDB.Bson.Serialization.Serializers;
+using Mimir.MongoDB.Bson.Serialization;
 using Mimir.Options;
 using MongoDB.Bson;
-using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 using MongoDB.Driver.GridFS;
 
@@ -16,7 +15,7 @@ public class MongoDbService
 
     public MongoDbService(IOptions<DatabaseOption> databaseOption)
     {
-        BsonSerializer.RegisterSerializer(new LibplanetCryptoAddressBsonSerializer());
+        SerializationRegistry.Register();
         var settings = MongoClientSettings.FromUrl(
             new MongoUrl(databaseOption.Value.ConnectionString)
         );


### PR DESCRIPTION
- Integrate `AvatarDocument` MongoDB model with GraphQL schema.
- Introduce `SerializationRegistry`.
- Introduce and register several BsonSerializers.
- Apply several attribute to for Bson deserialization and GraphQL schema generation.
- Add `AvatarRepository.GetByAddressAsync`.
- Move "avatar" GraphQL query.
