### PR TITLE
Handle bencodex null product

### DIFF
--- a/Mimir.Worker/ActionHandler/ProductsHandler.cs
+++ b/Mimir.Worker/ActionHandler/ProductsHandler.cs
@@ -145,9 +145,25 @@ public class ProductsHandler(IStateService stateService, MongoDbService store)
 
         foreach (var productId in productsToAdd)
         {
-            var product = await StateGetter.GetProductState(productId);
-            var document = CreateProductDocumentAsync(avatarAddress, productsStateAddress, product);
-            documents.Add(document);
+            try
+            {
+                var product = await StateGetter.GetProductState(productId);
+                var document = CreateProductDocumentAsync(
+                    avatarAddress,
+                    productsStateAddress,
+                    product
+                );
+                documents.Add(document);
+            }
+            catch (StateIsNullException err)
+            {
+                Logger.Error(
+                    "{AvatarAddress} Product[{ProductID}] is exists but state is `Bencodex Null`, err: {Error}",
+                    avatarAddress,
+                    productId,
+                    err
+                );
+            }
         }
 
         if (documents.Count > 0)

--- a/Mimir.Worker/Exceptions/StateIsNullException.cs
+++ b/Mimir.Worker/Exceptions/StateIsNullException.cs
@@ -1,0 +1,16 @@
+using Libplanet.Crypto;
+
+namespace Mimir.Worker.Exceptions;
+
+public class StateIsNullException : Exception
+{
+    public StateIsNullException(
+        Address stateAddress,
+        Type stateType,
+        Exception? innerException = null
+    )
+        : base(
+            $"State is Bencodex.Types.Null for '{stateAddress}({stateType.Name})",
+            innerException
+        ) { }
+}

--- a/Mimir.Worker/Util/StateGetter.cs
+++ b/Mimir.Worker/Util/StateGetter.cs
@@ -229,6 +229,14 @@ public class StateGetter
             );
         }
 
+        if (state is Null)
+        {
+            throw new StateIsNullException(
+                ProductsState.DeriveAddress(productAddress),
+                typeof(Lib9c.Models.Market.Product)
+            );
+        }
+
         return Lib9c.Models.Factories.ProductFactory.DeserializeProduct(state);
     }
 


### PR DESCRIPTION
Sometimes the product exists, but its state is `Bencodex.Types.Null`
I think this is an abnormal situation, likely caused by an error or remnants of past data.
Nevertheless, we should handle it appropriately.