### PR TITLE
feat: add "balance" GraphQL query

### DIFF
--- a/Lib9c.GraphQL/Enums/CurrencyMethodType.cs
+++ b/Lib9c.GraphQL/Enums/CurrencyMethodType.cs
@@ -1,0 +1,8 @@
+namespace Lib9c.GraphQL.Enums;
+
+public enum CurrencyMethodType
+{
+    Legacy,
+    Capped,
+    Uncapped,
+}

--- a/Lib9c.GraphQL/Extensions/CurrencyInputExtensions.cs
+++ b/Lib9c.GraphQL/Extensions/CurrencyInputExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Immutable;
+using Lib9c.GraphQL.Enums;
+using Lib9c.GraphQL.InputObjects;
+using Libplanet.Types.Assets;
+
+namespace Lib9c.GraphQL.Extensions;
+
+public static class CurrencyInputExtensions
+{
+    public static Currency ToCurrency(this CurrencyInput input)
+    {
+        if (input is null)
+        {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        var minters = input.Minters?.ToImmutableHashSet();
+        return input.CurrencyMethodType switch
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            CurrencyMethodType.Legacy => Currency.Legacy(input.Ticker, input.DecimalPlaces, minters),
+#pragma warning restore CS0618 // Type or member is obsolete
+            CurrencyMethodType.Capped => Currency.Capped(
+                input.Ticker,
+                input.DecimalPlaces,
+                (input.MaximumSupplyMajor!.Value, input.MaximumSupplyMinor!.Value),
+                minters),
+            CurrencyMethodType.Uncapped => Currency.Uncapped(input.Ticker, input.DecimalPlaces, minters),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(input.CurrencyMethodType),
+                $"Unexpected currency type: {input.CurrencyMethodType}")
+        };
+    }
+}

--- a/Lib9c.GraphQL/Extensions/CurrencyTickerStringExtensions.cs
+++ b/Lib9c.GraphQL/Extensions/CurrencyTickerStringExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+
+namespace Lib9c.GraphQL.Extensions;
+
+public static class CurrencyTickerStringExtensions
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    private static readonly Currency OdinNCG = Currency.Legacy(
+        "NCG",
+        2,
+        new Address("0x47d082a115c63e7b58b1532d20e631538eafadde"));
+#pragma warning restore CS0618 // Type or member is obsolete
+
+    public static Currency ToCurrency(this string currencyTicker)
+    {
+        if (currencyTicker is null)
+        {
+            throw new ArgumentNullException(nameof(currencyTicker));
+        }
+
+        return currencyTicker switch
+        {
+            "NCG" => OdinNCG,
+            "Mead" => Currencies.Mead,
+            _ => Currencies.GetMinterlessCurrency(currencyTicker),
+        };
+    }
+}

--- a/Lib9c.GraphQL/InputObjectTypes/CurrencyInputType.cs
+++ b/Lib9c.GraphQL/InputObjectTypes/CurrencyInputType.cs
@@ -1,0 +1,34 @@
+using HotChocolate.Types;
+using Lib9c.GraphQL.Enums;
+using Lib9c.GraphQL.InputObjects;
+
+namespace Lib9c.GraphQL.Types;
+
+public class CurrencyInputType : InputObjectType<CurrencyInput>
+{
+    protected override void Configure(IInputObjectTypeDescriptor<CurrencyInput> descriptor)
+    {
+        descriptor
+            .Field(f => f.CurrencyMethodType)
+            .Type<NonNullType<EnumType<CurrencyMethodType>>>();
+        descriptor
+            .Field(f => f.Ticker)
+            .Type<NonNullType<StringType>>();
+        descriptor
+            .Field(f => f.DecimalPlaces)
+            .Type<NonNullType<ByteType>>();
+        descriptor
+            .Field(f => f.Minters)
+            .Type<ListType<AddressType>>();
+        descriptor
+            .Field(f => f.TotalSupplyTrackable)
+            .Type<NonNullType<BooleanType>>()
+            .DefaultValue(false);
+        descriptor
+            .Field(f => f.MaximumSupplyMajor)
+            .Type<LongType>();
+        descriptor
+            .Field(f => f.MaximumSupplyMinor)
+            .Type<LongType>();
+    }
+}

--- a/Lib9c.GraphQL/InputObjects/CurrencyInput.cs
+++ b/Lib9c.GraphQL/InputObjects/CurrencyInput.cs
@@ -1,0 +1,13 @@
+using Lib9c.GraphQL.Enums;
+using Libplanet.Crypto;
+
+namespace Lib9c.GraphQL.InputObjects;
+
+public record CurrencyInput(
+    CurrencyMethodType CurrencyMethodType,
+    string Ticker,
+    byte DecimalPlaces,
+    Address[]? Minters,
+    bool TotalSupplyTrackable,
+    long? MaximumSupplyMajor,
+    long? MaximumSupplyMinor);

--- a/Lib9c.GraphQL/Types/CurrencyType.cs
+++ b/Lib9c.GraphQL/Types/CurrencyType.cs
@@ -1,0 +1,29 @@
+using HotChocolate.Types;
+using Libplanet.Types.Assets;
+
+namespace Lib9c.GraphQL.Types;
+
+public class CurrencyType : ObjectType<Currency>
+{
+    protected override void Configure(IObjectTypeDescriptor<Currency> descriptor)
+    {
+        descriptor.BindFieldsExplicitly();
+
+        descriptor
+            .Field("ticker")
+            .Type<NonNullType<StringType>>()
+            .Resolve(context => context.Parent<Currency>().Ticker);
+        descriptor
+            .Field("decimalPlaces")
+            .Type<NonNullType<ByteType>>()
+            .Resolve(context => context.Parent<Currency>().DecimalPlaces);
+        descriptor
+            .Field("minters")
+            .Type<ListType<AddressType>>()
+            .Resolve(context => context.Parent<Currency>().Minters);
+        descriptor
+            .Field("totalSupplyTrackable")
+            .Type<NonNullType<BooleanType>>()
+            .Resolve(context => context.Parent<Currency>().TotalSupplyTrackable);
+    }
+}

--- a/Mimir.MongoDB/Bson/BalanceDocument.cs
+++ b/Mimir.MongoDB/Bson/BalanceDocument.cs
@@ -1,8 +1,7 @@
 using Libplanet.Crypto;
-using Libplanet.Types.Assets;
 using MongoDB.Bson.Serialization.Attributes;
 
 namespace Mimir.MongoDB.Bson;
 
 [BsonIgnoreExtraElements]
-public record BalanceDocument(Address Address, FungibleAssetValue Object) : MimirBsonDocument(Address);
+public record BalanceDocument(Address Address, string Object) : MimirBsonDocument(Address);

--- a/Mimir.Worker/Handler/BalanceHandler.cs
+++ b/Mimir.Worker/Handler/BalanceHandler.cs
@@ -11,10 +11,12 @@ public record BalanceHandler(Currency Currency) : IStateHandler
         if (context.RawState is not Integer value)
         {
             throw new InvalidCastException(
-                $"{nameof(context.RawState)} Invalid state type. Expected {nameof(Integer)}, got {context.RawState.GetType().Name}."
-            );
+                $"{nameof(context.RawState)} Invalid state type. " +
+                $"Expected {nameof(Integer)}, got {context.RawState.GetType().Name}.");
         }
 
-        return new BalanceDocument(context.Address, FungibleAssetValue.FromRawValue(Currency, value));
+        return new BalanceDocument(
+            context.Address,
+            FungibleAssetValue.FromRawValue(Currency, value).GetQuantityString());
     }
 }

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -1,3 +1,6 @@
+using HotChocolate.AspNetCore;
+using Lib9c.GraphQL.Extensions;
+using Lib9c.GraphQL.InputObjects;
 using Lib9c.Models.States;
 using Libplanet.Crypto;
 using Mimir.GraphQL.Objects;
@@ -14,8 +17,35 @@ public class Query
     /// <param name="collectionName">The name of the collection.</param>
     /// <param name="repo"></param>
     /// <returns>The metadata</returns>
-    public async Task<MetadataDocument> GetMetadataAsync(string collectionName, [Service] MetadataRepository repo)
-        => await repo.GetByCollectionAsync(collectionName);
+    public async Task<MetadataDocument> GetMetadataAsync(string collectionName, [Service] MetadataRepository repo) =>
+        await repo.GetByCollectionAsync(collectionName);
+
+    /// <summary>
+    /// Get the balance of a specific currency for a given address.
+    /// Choose one of the following parameters to specify the currency: currency, currencyTicker
+    /// </summary>
+    /// <param name="currency">The currency object.</param>
+    /// <param name="currencyTicker">The ticker of the currency.</param>
+    /// <param name="address">The address of the balance.</param>
+    /// <exception cref="GraphQLRequestException"></exception>
+    public async Task<string> GetBalanceAsync(
+        CurrencyInput? currency,
+        string? currencyTicker,
+        Address address,
+        [Service] BalanceRepository repo)
+    {
+        if (currency is not null)
+        {
+            return (await repo.GetByAddressAsync(currency.ToCurrency(), address)).Object;
+        }
+
+        if (currencyTicker is not null)
+        {
+            return (await repo.GetByAddressAsync(currencyTicker.ToCurrency(), address)).Object;
+        }
+
+        throw new GraphQLRequestException("Either currency or currencyTicker must be provided.");
+    }
 
     /// <summary>
     /// Get an agent state by address.

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -1,13 +1,8 @@
-using System.IdentityModel.Tokens.Jwt;
-using System.Net.Http.Headers;
-using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using Lib9c.GraphQL.Types;
 using Libplanet.Crypto;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Options;
-using Microsoft.IdentityModel.Tokens;
 using Mimir.GraphQL;
 using Mimir.Options;
 using Mimir.Repositories;
@@ -34,8 +29,9 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 builder.Services.AddAuthorization();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSingleton<MongoDbService>();
-builder.Services.AddSingleton<TableSheetsRepository>();
 builder.Services.AddSingleton<MetadataRepository>();
+builder.Services.AddSingleton<TableSheetsRepository>();
+builder.Services.AddSingleton<BalanceRepository>();
 builder.Services.AddSingleton<AgentRepository>();
 // AvatarState dependencies
 builder.Services.AddSingleton<AvatarRepository>();

--- a/Mimir/Repositories/BalanceRepository.cs
+++ b/Mimir/Repositories/BalanceRepository.cs
@@ -1,0 +1,29 @@
+using Libplanet.Crypto;
+using Libplanet.Types.Assets;
+using Mimir.Exceptions;
+using Mimir.MongoDB;
+using Mimir.MongoDB.Bson;
+using Mimir.Services;
+using MongoDB.Driver;
+
+namespace Mimir.Repositories;
+
+public class BalanceRepository(MongoDbService dbService)
+{
+    public async Task<BalanceDocument> GetByAddressAsync(Currency currency, Address address)
+    {
+        var accountAddress = new Address(currency.Hash.ToByteArray());
+        var collectionName = CollectionNames.GetCollectionName(accountAddress);
+        var collection = dbService.GetCollection<BalanceDocument>(collectionName);
+        var filter = Builders<BalanceDocument>.Filter.Eq("Address", address.ToHex());
+        var document = await collection.Find(filter).FirstOrDefaultAsync();
+        if (document is null)
+        {
+            throw new DocumentNotFoundInMongoCollectionException(
+                collection.CollectionNamespace.CollectionName,
+                $"'Address' equals to '{address.ToHex()}'");
+        }
+
+        return document;
+    }
+}


### PR DESCRIPTION
- Add `CurrencyType`, `CurrencyInputType` for GraphQL.
- Add `CurrencyTickerStringExtensions`.
- Add `BalanceRepository`
- Change type of `BalanceDocument.Object` from `FungibleAssetValue` to `string`.
- Add "balance" GraphQL query.
