### PR TITLE
Use .NET builtin JsonNode instead of 3rd-party

### DIFF
--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/MaterialSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/MaterialSerializer.cs
@@ -5,7 +5,7 @@ using Mimir.MongoDB.Json.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Items;
 
@@ -50,9 +50,10 @@ public class MaterialSerializer : ClassSerializerBase<Material>
 
     public static Material Deserialize(string jsonString)
     {
-        var material = JsonConvert.DeserializeObject<Material>(
+        var material = JsonSerializer.Deserialize<Material>(
             jsonString,
-            MimirBsonDocumentExtensions.JsonSerializerSettings);
+            MimirBsonDocumentExtensions.JsonSerializerOptions);  // Use JsonSerializerOptions from System.Text.Json
+
         if (material is null)
         {
             throw new BsonSerializationException("Failed to deserialize Material from JSON string.");

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/TradableMaterialSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/TradableMaterialSerializer.cs
@@ -5,7 +5,7 @@ using Mimir.MongoDB.Json.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Items;
 
@@ -46,9 +46,9 @@ public class TradableMaterialSerializer : ClassSerializerBase<TradableMaterial>
 
     public static TradableMaterial Deserialize(string jsonString)
     {
-        var material = JsonConvert.DeserializeObject<TradableMaterial>(
+        var material = JsonSerializer.Deserialize<TradableMaterial>(
             jsonString,
-            MimirBsonDocumentExtensions.JsonSerializerSettings);
+            MimirBsonDocumentExtensions.JsonSerializerOptions);
         if (material is null)
         {
             throw new BsonSerializationException("Failed to deserialize Material from JSON string.");

--- a/Mimir.MongoDB/Json/Converters/BigIntegerJsonConverter.cs
+++ b/Mimir.MongoDB/Json/Converters/BigIntegerJsonConverter.cs
@@ -1,42 +1,39 @@
 using System.Numerics;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
-namespace Mimir.MongoDB.Json.Converters;
-
-public class BigIntegerJsonConverter : JsonConverter<BigInteger>
+namespace Mimir.MongoDB.Json.Converters
 {
-    public override BigInteger ReadJson(
-        JsonReader reader,
-        Type objectType,
-        BigInteger existingValue,
-        bool hasExistingValue,
-        JsonSerializer serializer)
+    public class BigIntegerJsonConverter : JsonConverter<BigInteger>
     {
-        if (reader.TokenType == JsonToken.Null)
+        public override BigInteger Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            throw new JsonSerializationException("Cannot convert null value to BigInteger.");
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                throw new JsonException("Cannot convert null value to BigInteger.");
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var value = reader.GetString();
+                return BigInteger.Parse(value!);
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt64(out long value))
+                {
+                    return new BigInteger(value);
+                }
+                throw new JsonException("Invalid number format for BigInteger.");
+            }
+
+            throw new JsonException($"Unexpected token type: {reader.TokenType}.");
         }
 
-        if (reader.TokenType == JsonToken.String)
+        public override void Write(Utf8JsonWriter writer, BigInteger value, JsonSerializerOptions options)
         {
-            var value = (string)reader.Value!;
-            return BigInteger.Parse(value);
+            writer.WriteStringValue(value.ToString());
         }
-
-        if (reader.TokenType == JsonToken.Integer)
-        {
-            var value = (long)reader.Value!;
-            return new BigInteger(value);
-        }
-
-        throw new JsonSerializationException($"Unexpected token type: {reader.TokenType}.");
-    }
-
-    public override void WriteJson(
-        JsonWriter writer,
-        BigInteger value,
-        JsonSerializer serializer)
-    {
-        writer.WriteValue(value.ToString());
     }
 }

--- a/Mimir.MongoDB/Json/Extensions/MimirBsonDocumentExtensions.cs
+++ b/Mimir.MongoDB/Json/Extensions/MimirBsonDocumentExtensions.cs
@@ -1,26 +1,24 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Mimir.MongoDB.Bson;
 using Mimir.MongoDB.Json.Converters;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 namespace Mimir.MongoDB.Json.Extensions;
 
 public static class MimirBsonDocumentExtensions
 {
-    public static readonly JsonSerializerSettings JsonSerializerSettings = new()
+    public static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
-        Formatting = Formatting.None,
-        NullValueHandling = NullValueHandling.Ignore,
-        ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         Converters =
-        [
+        {
             new BigIntegerJsonConverter(),
             new MaterialAndIntDictionaryJsonConverter(),
-            new StringEnumConverter(),
-        ],
-        ContractResolver = new IgnoreBencodedContractResolver(),
+            new JsonStringEnumConverter(),
+        },
     };
 
     public static string ToJson(this MimirBsonDocument document) =>
-        JsonConvert.SerializeObject(document, JsonSerializerSettings);
+        JsonSerializer.Serialize(document, JsonSerializerOptions);
 }

--- a/Mimir.Worker/Poller/DiffPoller/DiffConsumer.cs
+++ b/Mimir.Worker/Poller/DiffPoller/DiffConsumer.cs
@@ -107,7 +107,7 @@ public class DiffConsumer
         }
 
         _logger.Information(
-            "{DiffCOunt} Handle in {Handler} Converted {Count} States",
+            "{DiffCount} Handle in {Handler} Converted {Count} States",
             diffResponse.AccountDiffs.Count(),
             handler.GetType().Name,
             documents.Count


### PR DESCRIPTION
Fixes issue #342 

Below are the listed files that required modification to 'System.Text.Json' types:

Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/TradableMaterialSerializer.cs
Mimir.MongoDB/Json/Converters/BigIntegerJsonConverter.cs
Mimir.MongoDB/Json/Converters/MaterialAndIntDictionaryJsonConverter.cs
Mimir.MongoDB/Json/Extensions/MimirBsonDocumentExtensions.cs

Note: Please merge PR #348 before merging this to avoid potential merge conflicts. 