### PR TITLE
feat: introduce GraphQL queries for world boss

### DIFF
--- a/Lib9c.Models/States/RaiderState.cs
+++ b/Lib9c.Models/States/RaiderState.cs
@@ -3,6 +3,7 @@ using Bencodex.Types;
 using Lib9c.Models.Exceptions;
 using Lib9c.Models.Extensions;
 using Libplanet.Crypto;
+using MongoDB.Bson.Serialization.Attributes;
 using ValueKind = Bencodex.Types.ValueKind;
 
 namespace Lib9c.Models.States;
@@ -25,6 +26,7 @@ public class RaiderState : IBencodable
     public int LatestBossLevel { get; init; }
     public long UpdatedBlockIndex { get; init; }
 
+    [BsonIgnore, GraphQLIgnore]
     public IValue Bencoded =>
         List
             .Empty.Add(TotalScore.Serialize())

--- a/Lib9c.Models/States/WorldBossKillRewardRecord.cs
+++ b/Lib9c.Models/States/WorldBossKillRewardRecord.cs
@@ -2,6 +2,7 @@ using Bencodex;
 using Bencodex.Types;
 using Lib9c.Models.Exceptions;
 using Lib9c.Models.Extensions;
+using MongoDB.Bson.Serialization.Attributes;
 using ValueKind = Bencodex.Types.ValueKind;
 
 namespace Lib9c.Models.States;
@@ -9,6 +10,15 @@ namespace Lib9c.Models.States;
 public record WorldBossKillRewardRecord : IBencodable
 {
     public Dictionary<int, bool> RewardRecordDictionary { get; init; }
+
+    [BsonIgnore, GraphQLIgnore]
+    public IValue Bencoded => RewardRecordDictionary
+        .OrderBy(kv => kv.Key)
+        .Aggregate(
+            List.Empty,
+            (current, kv) => current.Add(List.Empty
+                .Add(kv.Key.Serialize())
+                .Add(kv.Value.Serialize())));
 
     public WorldBossKillRewardRecord(IValue bencoded)
     {
@@ -31,13 +41,4 @@ public record WorldBossKillRewardRecord : IBencodable
             RewardRecordDictionary[key] = value;
         }
     }
-
-    public IValue Bencoded =>
-        RewardRecordDictionary
-            .OrderBy(kv => kv.Key)
-            .Aggregate(
-                List.Empty,
-                (current, kv) =>
-                    current.Add(List.Empty.Add(kv.Key.Serialize()).Add(kv.Value.Serialize()))
-            );
 }

--- a/Lib9c.Models/States/WorldBossState.cs
+++ b/Lib9c.Models/States/WorldBossState.cs
@@ -3,10 +3,12 @@ using Bencodex;
 using Bencodex.Types;
 using Lib9c.Models.Exceptions;
 using Lib9c.Models.Extensions;
+using MongoDB.Bson.Serialization.Attributes;
 using ValueKind = Bencodex.Types.ValueKind;
 
 namespace Lib9c.Models.States;
 
+[BsonIgnoreExtraElements]
 public record WorldBossState : IBencodable
 {
     public int Id { get; init; }
@@ -15,6 +17,7 @@ public record WorldBossState : IBencodable
     public long StartedBlockIndex { get; init; }
     public long EndedBlockIndex { get; init; }
 
+    [BsonIgnore, GraphQLIgnore]
     public IValue Bencoded =>
         List
             .Empty.Add(Id.Serialize())

--- a/Mimir.Worker/ActionHandler/BaseActionHandler.cs
+++ b/Mimir.Worker/ActionHandler/BaseActionHandler.cs
@@ -51,13 +51,13 @@ public abstract class BaseActionHandler(
         return await TryHandleAction(blockIndex, actionTypeStr, actionPlainValueInternal, session, stoppingToken);
     }
 
+    [Obsolete("Use the overload with actionType instead.")]
     protected virtual Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
         IAction action,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         return Task.FromResult(false);
     }

--- a/Mimir.Worker/ActionHandler/BaseActionHandler.cs
+++ b/Mimir.Worker/ActionHandler/BaseActionHandler.cs
@@ -13,8 +13,7 @@ public abstract class BaseActionHandler(
     IStateService stateService,
     MongoDbService store,
     string actionTypeRegex,
-    ILogger logger
-)
+    ILogger logger)
 {
     protected readonly IStateService StateService = stateService;
 
@@ -31,8 +30,7 @@ public abstract class BaseActionHandler(
         IValue? actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         if (await TryHandleAction(blockIndex, signer, action, session, stoppingToken))
         {
@@ -50,7 +48,7 @@ public abstract class BaseActionHandler(
             return false;
         }
 
-        return await TryHandleAction(actionTypeStr, blockIndex, actionPlainValueInternal, session, stoppingToken);
+        return await TryHandleAction(blockIndex, actionTypeStr, actionPlainValueInternal, session, stoppingToken);
     }
 
     protected virtual Task<bool> TryHandleAction(
@@ -65,12 +63,11 @@ public abstract class BaseActionHandler(
     }
 
     protected virtual Task<bool> TryHandleAction(
+        long blockIndex,
         string actionType,
-        long processBlockIndex,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         return Task.FromResult(false);
     }

--- a/Mimir.Worker/ActionHandler/CombinationSlotStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/CombinationSlotStateHandler.cs
@@ -20,8 +20,8 @@ public class CombinationSlotStateHandler(IStateService stateService, MongoDbServ
         Log.ForContext<CombinationSlotStateHandler>())
 {
     protected override async Task<bool> TryHandleAction(
+        long blockIndex,
         string actionType,
-        long processBlockIndex,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)

--- a/Mimir.Worker/ActionHandler/PatchTableHandler.cs
+++ b/Mimir.Worker/ActionHandler/PatchTableHandler.cs
@@ -34,12 +34,11 @@ public class PatchTableHandler(IStateService stateService, MongoDbService store)
     ];
 
     protected override async Task<bool> TryHandleAction(
+        long blockIndex,
         string actionType,
-        long processBlockIndex,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         if (actionPlainValueInternal is not Dictionary actionValues)
         {

--- a/Mimir.Worker/ActionHandler/PetStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/PetStateHandler.cs
@@ -19,12 +19,11 @@ public class PetStateHandler(IStateService stateService, MongoDbService store)
     )
 {
     protected override async Task<bool> TryHandleAction(
+        long blockIndex,
         string actionType,
-        long processBlockIndex,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         {
             if (actionPlainValueInternal is not Dictionary actionValues)

--- a/Mimir.Worker/ActionHandler/ProductsHandler.cs
+++ b/Mimir.Worker/ActionHandler/ProductsHandler.cs
@@ -21,8 +21,8 @@ public class ProductsHandler(IStateService stateService, MongoDbService store) :
         Log.ForContext<ProductsHandler>())
 {
     protected override async Task<bool> TryHandleAction(
+        long blockIndex,
         string actionType,
-        long processBlockIndex,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)

--- a/Mimir.Worker/ActionHandler/RaidHandler.cs
+++ b/Mimir.Worker/ActionHandler/RaidHandler.cs
@@ -1,6 +1,6 @@
-using Lib9c.Abstractions;
-using Libplanet.Action;
-using Libplanet.Crypto;
+using Bencodex.Types;
+using Lib9c.Models.Exceptions;
+using Lib9c.Models.Extensions;
 using Mimir.MongoDB;
 using Mimir.MongoDB.Bson;
 using Mimir.Worker.CollectionUpdaters;
@@ -18,92 +18,95 @@ public class RaidHandler(IStateService stateService, MongoDbService store)
     : BaseActionHandler(stateService, store, "^raid[0-9]*$", Log.ForContext<RaidHandler>())
 {
     protected override async Task<bool> TryHandleAction(
-        long blockIndex,
-        Address signer,
-        IAction action,
+        string actionType,
+        long processBlockIndex,
+        IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
-        if (action is not IRaidV2 raid)
+        if (actionPlainValueInternal is null)
         {
+            var e = new ArgumentNullException(nameof(actionPlainValueInternal));
+            Logger.Fatal(e, "Failed to handle action: {ActionType}", actionType);
             return false;
         }
+
+        if (actionPlainValueInternal is not Dictionary d)
+        {
+            var e = new UnsupportedArgumentTypeException<ValueKind>(
+                nameof(actionPlainValueInternal),
+                [ValueKind.Dictionary],
+                actionPlainValueInternal.Kind);
+            Logger.Fatal(e, "Failed to handle action: {ActionType}", actionType);
+            return false;
+        }
+
+        var avatarAddress = d["a"].ToAddress();
+        var equipmentIds = d["e"].ToList(StateExtensions.ToGuid);
+        var costumeIds = d["c"].ToList(StateExtensions.ToGuid);
+        Logger.Information("Handle raid, avatar: {AvatarAddress}", avatarAddress);
 
         await ItemSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,
             BattleType.Raid,
-            raid.AvatarAddress,
-            raid.CostumeIds,
-            raid.EquipmentIds,
+            avatarAddress,
+            costumeIds,
+            equipmentIds,
             session,
-            stoppingToken
-        );
+            stoppingToken);
 
-        var avatarAddress = raid.AvatarAddress;
-
-        Logger.Information("Handle raid, avatar: {avatarAddress}", avatarAddress);
-
-        var worldBossListSheet = await Store.GetSheetAsync<WorldBossListSheet>();
-
-        if (worldBossListSheet != null)
+        var worldBossListSheet = await Store.GetSheetAsync<WorldBossListSheet>(stoppingToken);
+        if (worldBossListSheet is null)
         {
-            int raidId;
-            try
-            {
-                var row = worldBossListSheet.FindRowByBlockIndex(blockIndex);
-                raidId = row.Id;
-            }
-            catch (InvalidOperationException)
-            {
-                Logger.Error("Failed to get this raidId.");
-                return false;
-            }
-
-            var worldBossAddress = Addresses.GetWorldBossAddress(raidId);
-            var raiderAddress = Addresses.GetRaiderAddress(avatarAddress, raidId);
-            var worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(
-                avatarAddress,
-                raidId
-            );
-
-            var worldBossState = await StateGetter.GetWorldBossState(worldBossAddress);
-            var raiderState = await StateGetter.GetRaiderState(raiderAddress);
-            var worldBossKillRewardRecordState =
-                await StateGetter.GetWorldBossKillRewardRecordState(
-                    worldBossKillRewardRecordAddress
-                );
-
-            await Store.UpsertStateDataManyAsync(
-                CollectionNames.GetCollectionName<WorldBossStateDocument>(),
-                [new WorldBossStateDocument(worldBossAddress, raidId, worldBossState)],
-                session,
-                stoppingToken
-            );
-            await Store.UpsertStateDataManyAsync(
-                CollectionNames.GetCollectionName<RaiderStateDocument>(),
-                [new RaiderStateDocument(raiderAddress, raiderState)],
-                session,
-                stoppingToken
-            );
-            await Store.UpsertStateDataManyAsync(
-                CollectionNames.GetCollectionName<WorldBossKillRewardRecordDocument>(),
-                [
-                    new WorldBossKillRewardRecordDocument(
-                        worldBossKillRewardRecordAddress,
-                        avatarAddress,
-                        worldBossKillRewardRecordState
-                    )
-                ],
-                session,
-                stoppingToken
-            );
+            Logger.Fatal("RaidActionHandler requires worldBossListSheet");
+            return false;
         }
-        else
+
+        int raidId;
+        try
         {
-            Logger.Error("RaidActionHandler requires worldBossListSheet.");
+            var row = worldBossListSheet.FindRowByBlockIndex(processBlockIndex);
+            raidId = row.Id;
         }
+        catch (InvalidOperationException)
+        {
+            Logger.Fatal("Failed to get this raidId");
+            return false;
+        }
+
+        var worldBossAddress = Addresses.GetWorldBossAddress(raidId);
+        var worldBossState = await StateGetter.GetWorldBossStateAsync(worldBossAddress, stoppingToken);
+        await Store.UpsertStateDataManyAsync(
+            CollectionNames.GetCollectionName<WorldBossStateDocument>(),
+            [new WorldBossStateDocument(worldBossAddress, raidId, worldBossState)],
+            session,
+            stoppingToken);
+
+        var raiderAddress = Addresses.GetRaiderAddress(avatarAddress, raidId);
+        var raiderState = await StateGetter.GetRaiderStateAsync(raiderAddress, stoppingToken);
+        await Store.UpsertStateDataManyAsync(
+            CollectionNames.GetCollectionName<RaiderStateDocument>(),
+            [new RaiderStateDocument(raiderAddress, raiderState)],
+            session,
+            stoppingToken);
+
+        var worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(
+            avatarAddress,
+            raidId);
+        var worldBossKillRewardRecordState = await StateGetter.GetWorldBossKillRewardRecordStateAsync(
+            worldBossKillRewardRecordAddress,
+            stoppingToken);
+        await Store.UpsertStateDataManyAsync(
+            CollectionNames.GetCollectionName<WorldBossKillRewardRecordDocument>(),
+            [
+                new WorldBossKillRewardRecordDocument(
+                    worldBossKillRewardRecordAddress,
+                    avatarAddress,
+                    worldBossKillRewardRecordState)
+            ],
+            session,
+            stoppingToken);
 
         return true;
     }

--- a/Mimir.Worker/ActionHandler/RaidHandler.cs
+++ b/Mimir.Worker/ActionHandler/RaidHandler.cs
@@ -18,8 +18,8 @@ public class RaidHandler(IStateService stateService, MongoDbService store)
     : BaseActionHandler(stateService, store, "^raid[0-9]*$", Log.ForContext<RaidHandler>())
 {
     protected override async Task<bool> TryHandleAction(
+        long blockIndex,
         string actionType,
-        long processBlockIndex,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
@@ -66,7 +66,7 @@ public class RaidHandler(IStateService stateService, MongoDbService store)
         int raidId;
         try
         {
-            var row = worldBossListSheet.FindRowByBlockIndex(processBlockIndex);
+            var row = worldBossListSheet.FindRowByBlockIndex(blockIndex);
             raidId = row.Id;
         }
         catch (InvalidOperationException)

--- a/Mimir.Worker/ActionHandler/RapidCombinationHandler.cs
+++ b/Mimir.Worker/ActionHandler/RapidCombinationHandler.cs
@@ -18,8 +18,8 @@ public class RapidCombinationHandler(IStateService stateService, MongoDbService 
         Log.ForContext<RapidCombinationHandler>())
 {
     protected override async Task<bool> TryHandleAction(
+        long blockIndex,
         string actionType,
-        long processBlockIndex,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)

--- a/Mimir.Worker/Util/StateGetter.cs
+++ b/Mimir.Worker/Util/StateGetter.cs
@@ -243,13 +243,11 @@ public class StateGetter
         };
     }
 
-    public async Task<WorldBossState> GetWorldBossState(
+    public async Task<WorldBossState> GetWorldBossStateAsync(
         Address worldBossAddress,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         var state = await _service.GetState(worldBossAddress, stoppingToken);
-
         if (state is null)
         {
             throw new StateNotFoundException(worldBossAddress, typeof(WorldBossState));
@@ -258,13 +256,11 @@ public class StateGetter
         return new WorldBossState(state);
     }
 
-    public async Task<RaiderState> GetRaiderState(
+    public async Task<RaiderState> GetRaiderStateAsync(
         Address raiderAddress,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         var state = await _service.GetState(raiderAddress, stoppingToken);
-
         if (state is null)
         {
             throw new StateNotFoundException(raiderAddress, typeof(RaiderState));
@@ -273,19 +269,14 @@ public class StateGetter
         return new RaiderState(state);
     }
 
-    public async Task<WorldBossKillRewardRecord> GetWorldBossKillRewardRecordState(
+    public async Task<WorldBossKillRewardRecord> GetWorldBossKillRewardRecordStateAsync(
         Address worldBossKillRewardRecordAddress,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         var state = await _service.GetState(worldBossKillRewardRecordAddress, stoppingToken);
-
         if (state is null)
         {
-            throw new StateNotFoundException(
-                worldBossKillRewardRecordAddress,
-                typeof(WorldBossKillRewardRecord)
-            );
+            throw new StateNotFoundException(worldBossKillRewardRecordAddress, typeof(WorldBossKillRewardRecord));
         }
 
         return new WorldBossKillRewardRecord(state);

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -179,7 +179,7 @@ public class Query
         WorldBossListSheet.Row row;
         try
         {
-            row = worldBossListSheet.FindRowByBlockIndex(11736101);
+            row = worldBossListSheet.FindRowByBlockIndex(blockIndex);
         }
         catch (InvalidOperationException)
         {
@@ -207,7 +207,7 @@ public class Query
         WorldBossListSheet.Row row;
         try
         {
-            row = worldBossListSheet.FindRowByBlockIndex(11736101);
+            row = worldBossListSheet.FindRowByBlockIndex(blockIndex);
         }
         catch (InvalidOperationException)
         {

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -162,4 +162,32 @@ public class Query
         var worldBossAddress = Addresses.GetWorldBossAddress(raidId);
         return (await worldBossRepo.GetByAddressAsync(worldBossAddress)).Object;
     }
+
+    /// <summary>
+    /// Get the raider of world boss.
+    /// </summary>
+    public async Task<RaiderState> GetWorldBossRaiderAsync(
+        Address avatarAddress,
+        [Service] MetadataRepository metadataRepo,
+        [Service] TableSheetsRepository tableSheetsRepo,
+        [Service] WorldBossRaiderRepository worldBossRaiderRepo)
+    {
+        var collectionName = CollectionNames.GetCollectionName<WorldBossStateDocument>();
+        var metadataDocument = await metadataRepo.GetByCollectionAsync(collectionName);
+        var blockIndex = metadataDocument.LatestBlockIndex;
+        var worldBossListSheet = await tableSheetsRepo.GetSheetAsync<WorldBossListSheet>();
+        WorldBossListSheet.Row row;
+        try
+        {
+            row = worldBossListSheet.FindRowByBlockIndex(11736101);
+        }
+        catch (InvalidOperationException)
+        {
+            throw new GraphQLException($"Failed to find the world boss row by block index, {blockIndex}");
+        }
+
+        var raidId = row.Id;
+        var raiderAddress = Addresses.GetRaiderAddress(avatarAddress, raidId);
+        return (await worldBossRaiderRepo.GetByAddressAsync(raiderAddress)).Object;
+    }
 }

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -190,4 +190,32 @@ public class Query
         var raiderAddress = Addresses.GetRaiderAddress(avatarAddress, raidId);
         return (await worldBossRaiderRepo.GetByAddressAsync(raiderAddress)).Object;
     }
+
+    /// <summary>
+    /// Get the kill reward record of world boss.
+    /// </summary>
+    public async Task<WorldBossKillRewardRecord> GetWorldBossKillRewardAsync(
+        Address avatarAddress,
+        [Service] MetadataRepository metadataRepo,
+        [Service] TableSheetsRepository tableSheetsRepo,
+        [Service] WorldBossKillRewardRecordRepository worldBossKillRewardRecordRepo)
+    {
+        var collectionName = CollectionNames.GetCollectionName<WorldBossStateDocument>();
+        var metadataDocument = await metadataRepo.GetByCollectionAsync(collectionName);
+        var blockIndex = metadataDocument.LatestBlockIndex;
+        var worldBossListSheet = await tableSheetsRepo.GetSheetAsync<WorldBossListSheet>();
+        WorldBossListSheet.Row row;
+        try
+        {
+            row = worldBossListSheet.FindRowByBlockIndex(11736101);
+        }
+        catch (InvalidOperationException)
+        {
+            throw new GraphQLException($"Failed to find the world boss row by block index, {blockIndex}");
+        }
+
+        var raidId = row.Id;
+        var worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(avatarAddress, raidId);
+        return (await worldBossKillRewardRecordRepo.GetByAddressAsync(worldBossKillRewardRecordAddress)).Object;
+    }
 }

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -194,7 +194,7 @@ public class Query
     /// <summary>
     /// Get the kill reward record of world boss.
     /// </summary>
-    public async Task<WorldBossKillRewardRecord> GetWorldBossKillRewardAsync(
+    public async Task<WorldBossKillRewardRecord> GetWorldBossKillRewardRecordAsync(
         Address avatarAddress,
         [Service] MetadataRepository metadataRepo,
         [Service] TableSheetsRepository tableSheetsRepo,

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -45,11 +45,12 @@ builder.Services.AddSingleton<CombinationSlotStateRepository>();
 // builder.Services.AddSingleton<CollectionRepository>();
 builder.Services.AddSingleton<ItemSlotRepository>();
 builder.Services.AddSingleton<RuneSlotRepository>();
+// Others
 builder.Services.AddSingleton<ArenaRepository>();
 builder.Services.AddSingleton<StakeRepository>();
 builder.Services.AddSingleton<ProductsRepository>();
 builder.Services.AddSingleton<ProductRepository>();
-// builder.Services.AddSingleton<SeasonInfoRepository>();
+builder.Services.AddSingleton<WorldBossRepository>();
 builder.Services.AddCors();
 builder.Services.AddHttpClient();
 builder.Services

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddSingleton<ProductsRepository>();
 builder.Services.AddSingleton<ProductRepository>();
 builder.Services.AddSingleton<WorldBossRepository>();
 builder.Services.AddSingleton<WorldBossRaiderRepository>();
+builder.Services.AddSingleton<WorldBossKillRewardRecordRepository>();
 builder.Services.AddCors();
 builder.Services.AddHttpClient();
 builder.Services

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -51,6 +51,7 @@ builder.Services.AddSingleton<StakeRepository>();
 builder.Services.AddSingleton<ProductsRepository>();
 builder.Services.AddSingleton<ProductRepository>();
 builder.Services.AddSingleton<WorldBossRepository>();
+builder.Services.AddSingleton<WorldBossRaiderRepository>();
 builder.Services.AddCors();
 builder.Services.AddHttpClient();
 builder.Services

--- a/Mimir/Repositories/WorldBossKillRewardRecordRepository.cs
+++ b/Mimir/Repositories/WorldBossKillRewardRecordRepository.cs
@@ -1,0 +1,27 @@
+using Libplanet.Crypto;
+using Mimir.Exceptions;
+using Mimir.MongoDB;
+using Mimir.MongoDB.Bson;
+using Mimir.Services;
+using MongoDB.Driver;
+
+namespace Mimir.Repositories;
+
+public class WorldBossKillRewardRecordRepository(MongoDbService dbService)
+{
+    public async Task<WorldBossKillRewardRecordDocument> GetByAddressAsync(Address address)
+    {
+        var collectionName = CollectionNames.GetCollectionName<WorldBossKillRewardRecordDocument>();
+        var collection = dbService.GetCollection<WorldBossKillRewardRecordDocument>(collectionName);
+        var filter = Builders<WorldBossKillRewardRecordDocument>.Filter.Eq("Address", address.ToHex());
+        var document = await collection.Find(filter).FirstOrDefaultAsync();
+        if (document is null)
+        {
+            throw new DocumentNotFoundInMongoCollectionException(
+                collection.CollectionNamespace.CollectionName,
+                $"'Address' equals to '{address.ToHex()}'");
+        }
+
+        return document;
+    }
+}

--- a/Mimir/Repositories/WorldBossRaiderRepository.cs
+++ b/Mimir/Repositories/WorldBossRaiderRepository.cs
@@ -1,0 +1,27 @@
+using Libplanet.Crypto;
+using Mimir.Exceptions;
+using Mimir.MongoDB;
+using Mimir.MongoDB.Bson;
+using Mimir.Services;
+using MongoDB.Driver;
+
+namespace Mimir.Repositories;
+
+public class WorldBossRaiderRepository(MongoDbService dbService)
+{
+    public async Task<RaiderStateDocument> GetByAddressAsync(Address address)
+    {
+        var collectionName = CollectionNames.GetCollectionName<RaiderStateDocument>();
+        var collection = dbService.GetCollection<RaiderStateDocument>(collectionName);
+        var filter = Builders<RaiderStateDocument>.Filter.Eq("Address", address.ToHex());
+        var document = await collection.Find(filter).FirstOrDefaultAsync();
+        if (document is null)
+        {
+            throw new DocumentNotFoundInMongoCollectionException(
+                collection.CollectionNamespace.CollectionName,
+                $"'Address' equals to '{address.ToHex()}'");
+        }
+
+        return document;
+    }
+}

--- a/Mimir/Repositories/WorldBossRepository.cs
+++ b/Mimir/Repositories/WorldBossRepository.cs
@@ -1,0 +1,27 @@
+using Libplanet.Crypto;
+using Mimir.Exceptions;
+using Mimir.MongoDB;
+using Mimir.MongoDB.Bson;
+using Mimir.Services;
+using MongoDB.Driver;
+
+namespace Mimir.Repositories;
+
+public class WorldBossRepository(MongoDbService dbService)
+{
+    public async Task<WorldBossStateDocument> GetByAddressAsync(Address address)
+    {
+        var collectionName = CollectionNames.GetCollectionName<WorldBossStateDocument>();
+        var collection = dbService.GetCollection<WorldBossStateDocument>(collectionName);
+        var filter = Builders<WorldBossStateDocument>.Filter.Eq("Address", address.ToHex());
+        var document = await collection.Find(filter).FirstOrDefaultAsync();
+        if (document is null)
+        {
+            throw new DocumentNotFoundInMongoCollectionException(
+                collection.CollectionNamespace.CollectionName,
+                $"'Address' equals to '{address.ToHex()}'");
+        }
+
+        return document;
+    }
+}


### PR DESCRIPTION
# Changes

## New GraphQL queries

worldBoss: Retrieve a list of product ids that a specific avatar has listed in the market.
worldBossRaider: Look up a product by product Id.
worldBossKillRewardRecord: Retrieve all products in the marketplace.

# Examples

```graphql
query {
  worldBoss {
    id
    level
    startedBlockIndex
    endedBlockIndex
  }
  worldBossRaider(avatarAddress: "6ab1bBD3b293BB4239e078F6ECEf8653FCE08268") {
    avatarAddress
    avatarName
    claimedBlockIndex
    cp
    highScore
  }
  worldBossKillRewardRecord(
    avatarAddress: "6ab1bBD3b293BB4239e078F6ECEf8653FCE08268"
  ) {
    rewardRecordDictionary {
      key
      value
    }
  }
}
```
```json
{
  "data": {
    "worldBoss": {
      "id": 0,
      "level": 299,
      "startedBlockIndex": 11736101,
      "endedBlockIndex": 11887300
    },
    "worldBossRaider": {
      "avatarAddress": "0x6ab1bBD3b293BB4239e078F6ECEf8653FCE08268",
      "avatarName": "LuongThienDi",
      "claimedBlockIndex": 11817352,
      "cp": 81199,
      "highScore": 41274
    },
    "worldBossKillRewardRecord": {
      "rewardRecordDictionary": [
        {
          "key": 218,
          "value": true
        },
        {
          "key": 233,
          "value": true
        },
        {
          "key": 252,
          "value": true
        },
        {
          "key": 265,
          "value": false
        }
      ]
    }
  }
}
```