### PR TITLE
Use .NET 8 with C# 12

### DIFF
--- a/Lib9c.GraphQL/Lib9c.GraphQL.csproj
+++ b/Lib9c.GraphQL/Lib9c.GraphQL.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>12</LangVersion>
         <Nullable>enable</Nullable>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <OutputPath>.bin</OutputPath>

--- a/Lib9c.Models.Tests/Lib9c.Models.Tests.csproj
+++ b/Lib9c.Models.Tests/Lib9c.Models.Tests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>12</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/Lib9c.Models/Lib9c.Models.csproj
+++ b/Lib9c.Models/Lib9c.Models.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>12</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Mimir.MongoDB/Mimir.MongoDB.csproj
+++ b/Mimir.MongoDB/Mimir.MongoDB.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
+        <LangVersion>12</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/Mimir.Worker.Tests/Mimir.Worker.Tests.csproj
+++ b/Mimir.Worker.Tests/Mimir.Worker.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/Mimir.Worker/Mimir.Worker.csproj
+++ b/Mimir.Worker/Mimir.Worker.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Mimir.Worker</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-Mimir.Worker-bccda56f-4d38-484b-ab03-ebb26065c837</UserSecretsId>

--- a/Mimir/Mimir.csproj
+++ b/Mimir/Mimir.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Mimir</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>


### PR DESCRIPTION
I bumped .NET version to bump C# version to 12, to use [`required` modifier feature in C# 11](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/required).

Because Mimir and Mimir.Worker already use .NET 8 so they aren't changed in this pull request.