### PR TITLE
feat: handle actions as plain value

### DIFF
--- a/Mimir.Worker/ActionHandler/ApprovePledgeHandler.cs
+++ b/Mimir.Worker/ActionHandler/ApprovePledgeHandler.cs
@@ -17,7 +17,7 @@ public class ApprovePledgeHandler(IStateService stateService, MongoDbService sto
 {
     private static readonly ApprovePledge Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -28,6 +28,5 @@ public class ApprovePledgeHandler(IStateService stateService, MongoDbService sto
     {
         Action.LoadPlainValue(actionPlainValue);
         await PledgeCollectionUpdater.ApproveAsync(Store, Action.PatronAddress, session, stoppingToken);
-        return true;
     }
 }

--- a/Mimir.Worker/ActionHandler/ApprovePledgeHandler.cs
+++ b/Mimir.Worker/ActionHandler/ApprovePledgeHandler.cs
@@ -15,8 +15,6 @@ public class ApprovePledgeHandler(IStateService stateService, MongoDbService sto
         "^approve_pledge[0-9]*$",
         Log.ForContext<ApprovePledgeHandler>())
 {
-    private static readonly ApprovePledge Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -26,7 +24,8 @@ public class ApprovePledgeHandler(IStateService stateService, MongoDbService sto
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
-        await PledgeCollectionUpdater.ApproveAsync(Store, Action.PatronAddress, session, stoppingToken);
+        var action = new ApprovePledge();
+        action.LoadPlainValue(actionPlainValue);
+        await PledgeCollectionUpdater.ApproveAsync(Store, action.PatronAddress, session, stoppingToken);
     }
 }

--- a/Mimir.Worker/ActionHandler/BaseActionHandler.cs
+++ b/Mimir.Worker/ActionHandler/BaseActionHandler.cs
@@ -26,17 +26,11 @@ public abstract class BaseActionHandler(
     public async Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
-        IAction action,
         IValue? actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        if (await TryHandleAction(blockIndex, signer, action, session, stoppingToken))
-        {
-            return true;
-        }
-
         var actionTypeStr = actionType switch
         {
             Integer integer => integer.ToString(),
@@ -48,22 +42,18 @@ public abstract class BaseActionHandler(
             return false;
         }
 
-        return await TryHandleAction(blockIndex, actionTypeStr, actionPlainValueInternal, session, stoppingToken);
+        return await TryHandleAction(
+            blockIndex,
+            signer,
+            actionTypeStr,
+            actionPlainValueInternal,
+            session,
+            stoppingToken);
     }
 
-    [Obsolete("Use the overload with actionType instead.")]
     protected virtual Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
-        IAction action,
-        IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default)
-    {
-        return Task.FromResult(false);
-    }
-
-    protected virtual Task<bool> TryHandleAction(
-        long blockIndex,
         string actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,

--- a/Mimir.Worker/ActionHandler/BaseActionHandler.cs
+++ b/Mimir.Worker/ActionHandler/BaseActionHandler.cs
@@ -44,14 +44,13 @@ public abstract class BaseActionHandler(
         }
 
         Logger.Information(
-            "Attempting to handle action. {BlockIndex}, {TxId}, {ActionType}",
+            "Handling action. {BlockIndex}, {TxId}, {ActionType}",
             blockIndex,
             txId,
             actionTypeStr);
-        bool result;
         try
         {
-            result = await TryHandleAction(
+            await HandleAction(
                 blockIndex,
                 signer,
                 actionPlainValue,
@@ -64,7 +63,7 @@ public abstract class BaseActionHandler(
         {
             Logger.Fatal(
                 e,
-                "Failed to load plain value. {BlockIndex}, {TxId}, {ActionType}",
+                "Failed to handling action. {BlockIndex}, {TxId}, {ActionType}",
                 blockIndex,
                 txId,
                 actionTypeStr);
@@ -72,23 +71,20 @@ public abstract class BaseActionHandler(
         }
 
         Logger.Information(
-            "Successfully handled action. {BlockIndex}, {TxId}, {ActionType}",
+            "Finished handling action. {BlockIndex}, {TxId}, {ActionType}",
             blockIndex,
             txId,
             actionTypeStr);
-        return result;
+        return true;
     }
 
     // FIXME: `string actionType` argument may can be removed.
-    protected virtual Task<bool> TryHandleAction(
+    protected abstract Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
         string actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default)
-    {
-        return Task.FromResult(false);
-    }
+        CancellationToken stoppingToken = default);
 }

--- a/Mimir.Worker/ActionHandler/BaseActionHandler.cs
+++ b/Mimir.Worker/ActionHandler/BaseActionHandler.cs
@@ -1,6 +1,5 @@
 using System.Text.RegularExpressions;
 using Bencodex.Types;
-using Libplanet.Action;
 using Libplanet.Crypto;
 using Mimir.Worker.Services;
 using Mimir.Worker.Util;
@@ -43,14 +42,40 @@ public abstract class BaseActionHandler(
             return false;
         }
 
-        return await TryHandleAction(
-            blockIndex,
-            signer,
-            actionPlainValue,
+        Logger.Information(
+            "Attempting to handle action of type {ActionType} at block index {BlockIndex} for signer {Signer}",
             actionTypeStr,
-            actionPlainValueInternal,
-            session,
-            stoppingToken);
+            blockIndex,
+            signer);
+        bool result;
+        try
+        {
+            result = await TryHandleAction(
+                blockIndex,
+                signer,
+                actionPlainValue,
+                actionTypeStr,
+                actionPlainValueInternal,
+                session,
+                stoppingToken);
+        }
+        catch (Exception e)
+        {
+            Logger.Fatal(
+                e,
+                "Failed to load plain value for action: {ActionType} at block index {BlockIndex} for signer {Signer}",
+                actionType,
+                blockIndex,
+                signer);
+            return false;
+        }
+
+        Logger.Information(
+            "Successfully handled action of type {ActionType} at block index {BlockIndex} for signer {Signer}",
+            actionTypeStr,
+            blockIndex,
+            signer);
+        return result;
     }
 
     // FIXME: `string actionType` argument may can be removed.

--- a/Mimir.Worker/ActionHandler/BaseActionHandler.cs
+++ b/Mimir.Worker/ActionHandler/BaseActionHandler.cs
@@ -26,6 +26,7 @@ public abstract class BaseActionHandler(
     public async Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
+        IValue actionPlainValue,
         IValue? actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
@@ -45,15 +46,18 @@ public abstract class BaseActionHandler(
         return await TryHandleAction(
             blockIndex,
             signer,
+            actionPlainValue,
             actionTypeStr,
             actionPlainValueInternal,
             session,
             stoppingToken);
     }
 
+    // FIXME: `string actionType` argument may can be removed.
     protected virtual Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
+        IValue actionPlainValue,
         string actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,

--- a/Mimir.Worker/ActionHandler/BaseActionHandler.cs
+++ b/Mimir.Worker/ActionHandler/BaseActionHandler.cs
@@ -24,6 +24,7 @@ public abstract class BaseActionHandler(
 
     public async Task<bool> TryHandleAction(
         long blockIndex,
+        string txId,
         Address signer,
         IValue actionPlainValue,
         IValue? actionType,
@@ -43,10 +44,10 @@ public abstract class BaseActionHandler(
         }
 
         Logger.Information(
-            "Attempting to handle action of type {ActionType} at block index {BlockIndex} for signer {Signer}",
-            actionTypeStr,
+            "Attempting to handle action. {BlockIndex}, {TxId}, {ActionType}",
             blockIndex,
-            signer);
+            txId,
+            actionTypeStr);
         bool result;
         try
         {
@@ -63,18 +64,18 @@ public abstract class BaseActionHandler(
         {
             Logger.Fatal(
                 e,
-                "Failed to load plain value for action: {ActionType} at block index {BlockIndex} for signer {Signer}",
-                actionType,
+                "Failed to load plain value. {BlockIndex}, {TxId}, {ActionType}",
                 blockIndex,
-                signer);
+                txId,
+                actionTypeStr);
             return false;
         }
 
         Logger.Information(
-            "Successfully handled action of type {ActionType} at block index {BlockIndex} for signer {Signer}",
-            actionTypeStr,
+            "Successfully handled action. {BlockIndex}, {TxId}, {ActionType}",
             blockIndex,
-            signer);
+            txId,
+            actionTypeStr);
         return result;
     }
 

--- a/Mimir.Worker/ActionHandler/BattleArenaHandler.cs
+++ b/Mimir.Worker/ActionHandler/BattleArenaHandler.cs
@@ -19,7 +19,7 @@ public class BattleArenaHandler(IStateService stateService, MongoDbService store
 {
     private static readonly BattleArena Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -39,7 +39,6 @@ public class BattleArenaHandler(IStateService stateService, MongoDbService store
             null,
             stoppingToken);
         await ProcessArena(blockIndex, Action, session, stoppingToken);
-        return true;
     }
 
     private async Task ProcessArena(

--- a/Mimir.Worker/ActionHandler/BattleArenaHandler.cs
+++ b/Mimir.Worker/ActionHandler/BattleArenaHandler.cs
@@ -17,8 +17,6 @@ public class BattleArenaHandler(IStateService stateService, MongoDbService store
         "^battle_arena[0-9]*$",
         Log.ForContext<BattleArenaHandler>())
 {
-    private static readonly BattleArena Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -28,21 +26,21 @@ public class BattleArenaHandler(IStateService stateService, MongoDbService store
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
+        var action = new BattleArena();
+        action.LoadPlainValue(actionPlainValue);
         await ItemSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,
             BattleType.Arena,
-            Action.myAvatarAddress,
-            Action.costumes,
-            Action.equipments,
+            action.myAvatarAddress,
+            action.costumes,
+            action.equipments,
             null,
             stoppingToken);
-        await ProcessArena(blockIndex, Action, session, stoppingToken);
+        await ProcessArena(action, session, stoppingToken);
     }
 
     private async Task ProcessArena(
-        long blockIndex,
         BattleArena battleArena,
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)

--- a/Mimir.Worker/ActionHandler/EndPledgeHandler.cs
+++ b/Mimir.Worker/ActionHandler/EndPledgeHandler.cs
@@ -17,8 +17,6 @@ public class EndPledgeHandler(IStateService stateService, MongoDbService store)
         "^end_pledge[0-9]*$",
         Log.ForContext<EndPledgeHandler>())
 {
-    private static readonly EndPledge Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -28,10 +26,11 @@ public class EndPledgeHandler(IStateService stateService, MongoDbService store)
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
+        var action = new EndPledge();
+        action.LoadPlainValue(actionPlainValue);
         await PledgeCollectionUpdater.DeleteAsync(
             Store,
-            Action.AgentAddress.GetPledgeAddress(),
+            action.AgentAddress.GetPledgeAddress(),
             session,
             stoppingToken);
     }

--- a/Mimir.Worker/ActionHandler/EndPledgeHandler.cs
+++ b/Mimir.Worker/ActionHandler/EndPledgeHandler.cs
@@ -19,7 +19,7 @@ public class EndPledgeHandler(IStateService stateService, MongoDbService store)
 {
     private static readonly EndPledge Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -34,6 +34,5 @@ public class EndPledgeHandler(IStateService stateService, MongoDbService store)
             Action.AgentAddress.GetPledgeAddress(),
             session,
             stoppingToken);
-        return true;
     }
 }

--- a/Mimir.Worker/ActionHandler/EventDungeonBattleHandler.cs
+++ b/Mimir.Worker/ActionHandler/EventDungeonBattleHandler.cs
@@ -18,7 +18,7 @@ public class EventDungeonBattleHandler(IStateService stateService, MongoDbServic
 {
     private static readonly EventDungeonBattle Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -36,8 +36,6 @@ public class EventDungeonBattleHandler(IStateService stateService, MongoDbServic
             Action.Costumes,
             Action.Equipments,
             session,
-            stoppingToken
-        );
-        return true;
+            stoppingToken);
     }
 }

--- a/Mimir.Worker/ActionHandler/EventDungeonBattleHandler.cs
+++ b/Mimir.Worker/ActionHandler/EventDungeonBattleHandler.cs
@@ -16,8 +16,6 @@ public class EventDungeonBattleHandler(IStateService stateService, MongoDbServic
         "^event_dungeon_battle[0-9]*$",
         Log.ForContext<EventDungeonBattleHandler>())
 {
-    private static readonly EventDungeonBattle Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -27,14 +25,15 @@ public class EventDungeonBattleHandler(IStateService stateService, MongoDbServic
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
+        var action = new EventDungeonBattle();
+        action.LoadPlainValue(actionPlainValue);
         await ItemSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,
             BattleType.Adventure,
-            Action.AvatarAddress,
-            Action.Costumes,
-            Action.Equipments,
+            action.AvatarAddress,
+            action.Costumes,
+            action.Equipments,
             session,
             stoppingToken);
     }

--- a/Mimir.Worker/ActionHandler/HackAndSlashHandler.cs
+++ b/Mimir.Worker/ActionHandler/HackAndSlashHandler.cs
@@ -16,8 +16,6 @@ public class HackAndSlashHandler(IStateService stateService, MongoDbService stor
         "^hack_and_slash[0-9]*$",
         Log.ForContext<HackAndSlashHandler>())
 {
-    private static readonly HackAndSlash Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -27,14 +25,15 @@ public class HackAndSlashHandler(IStateService stateService, MongoDbService stor
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
+        var action = new HackAndSlash();
+        action.LoadPlainValue(actionPlainValue);
         await ItemSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,
             BattleType.Adventure,
-            Action.AvatarAddress,
-            Action.Costumes,
-            Action.Equipments,
+            action.AvatarAddress,
+            action.Costumes,
+            action.Equipments,
             session,
             stoppingToken);
     }

--- a/Mimir.Worker/ActionHandler/HackAndSlashHandler.cs
+++ b/Mimir.Worker/ActionHandler/HackAndSlashHandler.cs
@@ -18,7 +18,7 @@ public class HackAndSlashHandler(IStateService stateService, MongoDbService stor
 {
     private static readonly HackAndSlash Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -36,8 +36,6 @@ public class HackAndSlashHandler(IStateService stateService, MongoDbService stor
             Action.Costumes,
             Action.Equipments,
             session,
-            stoppingToken
-        );
-        return true;
+            stoppingToken);
     }
 }

--- a/Mimir.Worker/ActionHandler/HackAndSlashSweepHandler.cs
+++ b/Mimir.Worker/ActionHandler/HackAndSlashSweepHandler.cs
@@ -16,8 +16,6 @@ public class HackAndSlashSweepHandler(IStateService stateService, MongoDbService
         "^hack_and_slash_sweep[0-9]*$",
         Log.ForContext<HackAndSlashSweepHandler>())
 {
-    private static readonly HackAndSlashSweep Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -27,14 +25,15 @@ public class HackAndSlashSweepHandler(IStateService stateService, MongoDbService
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
+        var action = new HackAndSlashSweep();
+        action.LoadPlainValue(actionPlainValue);
         await ItemSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,
             BattleType.Adventure,
-            Action.avatarAddress,
-            Action.costumes,
-            Action.equipments,
+            action.avatarAddress,
+            action.costumes,
+            action.equipments,
             session,
             stoppingToken);
     }

--- a/Mimir.Worker/ActionHandler/HackAndSlashSweepHandler.cs
+++ b/Mimir.Worker/ActionHandler/HackAndSlashSweepHandler.cs
@@ -18,7 +18,7 @@ public class HackAndSlashSweepHandler(IStateService stateService, MongoDbService
 {
     private static readonly HackAndSlashSweep Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -36,8 +36,6 @@ public class HackAndSlashSweepHandler(IStateService stateService, MongoDbService
             Action.costumes,
             Action.equipments,
             session,
-            stoppingToken
-        );
-        return true;
+            stoppingToken);
     }
 }

--- a/Mimir.Worker/ActionHandler/JoinArenaHandler.cs
+++ b/Mimir.Worker/ActionHandler/JoinArenaHandler.cs
@@ -1,74 +1,68 @@
-using Lib9c.Abstractions;
+using Bencodex.Types;
 using Lib9c.Models.States;
-using Libplanet.Action;
 using Libplanet.Crypto;
 using Mimir.Worker.CollectionUpdaters;
 using Mimir.Worker.Services;
 using MongoDB.Driver;
+using Nekoyume.Action;
 using Nekoyume.Model.EnumType;
 using Serilog;
 
 namespace Mimir.Worker.ActionHandler;
 
-public class JoinArenaHandler(IStateService stateService, MongoDbService store)
-    : BaseActionHandler(
+public class JoinArenaHandler(IStateService stateService, MongoDbService store) :
+    BaseActionHandler(
         stateService,
         store,
         "^join_arena[0-9]*$",
-        Log.ForContext<JoinArenaHandler>()
-    )
+        Log.ForContext<JoinArenaHandler>())
 {
+    private static readonly JoinArena Action = new();
+
     protected override async Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
-        IAction action,
+        IValue actionPlainValue,
+        string actionType,
+        IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
-        if (action is not IJoinArenaV1 joinArena)
-        {
-            return false;
-        }
-
-        Logger.Information("Handle join_arena, address: {AvatarAddress}", joinArena.AvatarAddress);
-
+        Action.LoadPlainValue(actionPlainValue);
         await ItemSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,
             BattleType.Arena,
-            joinArena.AvatarAddress,
-            joinArena.Costumes,
-            joinArena.Equipments,
+            Action.avatarAddress,
+            Action.costumes,
+            Action.equipments,
             session,
             stoppingToken
         );
-
-        await ProcessArena(joinArena, session, stoppingToken);
-
+        await ProcessArena(Action, session, stoppingToken);
         return true;
     }
 
     private async Task ProcessArena(
-        IJoinArenaV1 joinArena,
+        JoinArena joinArena,
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default
     )
     {
         var arenaScore = await StateGetter.GetArenaScoreAsync(
-            joinArena.AvatarAddress,
-            joinArena.ChampionshipId,
-            joinArena.Round,
+            joinArena.avatarAddress,
+            joinArena.championshipId,
+            joinArena.round,
             stoppingToken
         );
         var arenaInfo = await StateGetter.GetArenaInformationAsync(
-            joinArena.AvatarAddress,
-            joinArena.ChampionshipId,
-            joinArena.Round,
+            joinArena.avatarAddress,
+            joinArena.championshipId,
+            joinArena.round,
             stoppingToken
         );
         var avatarState = await StateGetter.GetAvatarState(
-            joinArena.AvatarAddress,
+            joinArena.avatarAddress,
             stoppingToken
         );
         var simpleAvatarState = SimplifiedAvatarState.FromAvatarState(avatarState);
@@ -77,9 +71,9 @@ public class JoinArenaHandler(IStateService stateService, MongoDbService store)
             simpleAvatarState,
             arenaScore,
             arenaInfo,
-            joinArena.AvatarAddress,
-            joinArena.ChampionshipId,
-            joinArena.Round,
+            joinArena.avatarAddress,
+            joinArena.championshipId,
+            joinArena.round,
             session,
             stoppingToken
         );

--- a/Mimir.Worker/ActionHandler/JoinArenaHandler.cs
+++ b/Mimir.Worker/ActionHandler/JoinArenaHandler.cs
@@ -19,7 +19,7 @@ public class JoinArenaHandler(IStateService stateService, MongoDbService store) 
 {
     private static readonly JoinArena Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -37,34 +37,28 @@ public class JoinArenaHandler(IStateService stateService, MongoDbService store) 
             Action.costumes,
             Action.equipments,
             session,
-            stoppingToken
-        );
+            stoppingToken);
         await ProcessArena(Action, session, stoppingToken);
-        return true;
     }
 
     private async Task ProcessArena(
         JoinArena joinArena,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         var arenaScore = await StateGetter.GetArenaScoreAsync(
             joinArena.avatarAddress,
             joinArena.championshipId,
             joinArena.round,
-            stoppingToken
-        );
+            stoppingToken);
         var arenaInfo = await StateGetter.GetArenaInformationAsync(
             joinArena.avatarAddress,
             joinArena.championshipId,
             joinArena.round,
-            stoppingToken
-        );
+            stoppingToken);
         var avatarState = await StateGetter.GetAvatarState(
             joinArena.avatarAddress,
-            stoppingToken
-        );
+            stoppingToken);
         var simpleAvatarState = SimplifiedAvatarState.FromAvatarState(avatarState);
         await ArenaCollectionUpdater.UpsertAsync(
             Store,
@@ -75,7 +69,6 @@ public class JoinArenaHandler(IStateService stateService, MongoDbService store) 
             joinArena.championshipId,
             joinArena.round,
             session,
-            stoppingToken
-        );
+            stoppingToken);
     }
 }

--- a/Mimir.Worker/ActionHandler/JoinArenaHandler.cs
+++ b/Mimir.Worker/ActionHandler/JoinArenaHandler.cs
@@ -17,8 +17,6 @@ public class JoinArenaHandler(IStateService stateService, MongoDbService store) 
         "^join_arena[0-9]*$",
         Log.ForContext<JoinArenaHandler>())
 {
-    private static readonly JoinArena Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -28,17 +26,18 @@ public class JoinArenaHandler(IStateService stateService, MongoDbService store) 
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
+        var action = new JoinArena();
+        action.LoadPlainValue(actionPlainValue);
         await ItemSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,
             BattleType.Arena,
-            Action.avatarAddress,
-            Action.costumes,
-            Action.equipments,
+            action.avatarAddress,
+            action.costumes,
+            action.equipments,
             session,
             stoppingToken);
-        await ProcessArena(Action, session, stoppingToken);
+        await ProcessArena(action, session, stoppingToken);
     }
 
     private async Task ProcessArena(

--- a/Mimir.Worker/ActionHandler/PatchTableHandler.cs
+++ b/Mimir.Worker/ActionHandler/PatchTableHandler.cs
@@ -63,8 +63,6 @@ public class PatchTableHandler(IStateService stateService, MongoDbService store)
                 $"Unable to find a class type matching the table name '{tableName}' in the specified namespace.");
         }
 
-        Logger.Information("Handle patch_table, table: {TableName} ", tableName);
-
         await SyncSheetStateAsync(tableName, sheetType, session, stoppingToken);
     }
 

--- a/Mimir.Worker/ActionHandler/PatchTableHandler.cs
+++ b/Mimir.Worker/ActionHandler/PatchTableHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using Bencodex.Types;
 using Lib9c.Models.Extensions;
+using Libplanet.Crypto;
 using Mimir.MongoDB;
 using Mimir.MongoDB.Bson;
 using Mimir.Worker.Exceptions;
@@ -35,6 +36,8 @@ public class PatchTableHandler(IStateService stateService, MongoDbService store)
 
     protected override async Task<bool> TryHandleAction(
         long blockIndex,
+        Address signer,
+        IValue actionPlainValue,
         string actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,

--- a/Mimir.Worker/ActionHandler/PatchTableHandler.cs
+++ b/Mimir.Worker/ActionHandler/PatchTableHandler.cs
@@ -14,13 +14,12 @@ using Serilog;
 
 namespace Mimir.Worker.ActionHandler;
 
-public class PatchTableHandler(IStateService stateService, MongoDbService store)
-    : BaseActionHandler(
+public class PatchTableHandler(IStateService stateService, MongoDbService store) :
+    BaseActionHandler(
         stateService,
         store,
         "^patch_table_sheet[0-9]*$",
-        Log.ForContext<PatchTableHandler>()
-    )
+        Log.ForContext<PatchTableHandler>())
 {
     private static readonly ImmutableArray<Type> SheetTypes =
     [
@@ -30,11 +29,10 @@ public class PatchTableHandler(IStateService stateService, MongoDbService store)
                 type.Namespace is { } @namespace
                 && @namespace.StartsWith($"{nameof(Nekoyume)}.{nameof(Nekoyume.TableData)}")
                 && !type.IsAbstract
-                && typeof(ISheet).IsAssignableFrom(type)
-            )
+                && typeof(ISheet).IsAssignableFrom(type))
     ];
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -47,8 +45,7 @@ public class PatchTableHandler(IStateService stateService, MongoDbService store)
         {
             throw new InvalidTypeOfActionPlainValueInternalException(
                 [ValueKind.Dictionary],
-                actionPlainValueInternal?.Kind
-            );
+                actionPlainValueInternal?.Kind);
         }
 
         var tableName = ((Text)actionValues["table_name"]).ToDotnetString();
@@ -63,22 +60,19 @@ public class PatchTableHandler(IStateService stateService, MongoDbService store)
         if (sheetType == null)
         {
             throw new TypeLoadException(
-                $"Unable to find a class type matching the table name '{tableName}' in the specified namespace."
-            );
+                $"Unable to find a class type matching the table name '{tableName}' in the specified namespace.");
         }
 
         Logger.Information("Handle patch_table, table: {TableName} ", tableName);
 
         await SyncSheetStateAsync(tableName, sheetType, session, stoppingToken);
-        return true;
     }
 
     public async Task SyncSheetStateAsync(
         string sheetName,
         Type sheetType,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
         if (sheetType == typeof(ItemSheet) || sheetType == typeof(QuestSheet))
         {
@@ -86,14 +80,11 @@ public class PatchTableHandler(IStateService stateService, MongoDbService store)
             return;
         }
 
-        if (
-            sheetType == typeof(WorldBossKillRewardSheet)
-            || sheetType == typeof(WorldBossBattleRewardSheet)
-        )
+        if (sheetType == typeof(WorldBossKillRewardSheet) ||
+            sheetType == typeof(WorldBossBattleRewardSheet))
         {
             Logger.Information(
-                "WorldBossKillRewardSheet, WorldBossBattleRewardSheet will handling later"
-            );
+                "WorldBossKillRewardSheet, WorldBossBattleRewardSheet will handling later");
             return;
         }
 
@@ -113,12 +104,10 @@ public class PatchTableHandler(IStateService stateService, MongoDbService store)
         sheet.Set(sheetValue.Value);
 
         var document = new SheetDocument(sheetAddress, sheet, sheetName, sheetState);
-
         await Store.UpsertSheetDocumentAsync(
             CollectionNames.GetCollectionName<SheetDocument>(),
             [document],
             session,
-            stoppingToken
-        );
+            stoppingToken);
     }
 }

--- a/Mimir.Worker/ActionHandler/PetStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/PetStateHandler.cs
@@ -21,6 +21,8 @@ public class PetStateHandler(IStateService stateService, MongoDbService store)
 {
     protected override async Task<bool> TryHandleAction(
         long blockIndex,
+        Address signer,
+        IValue actionPlainValue,
         string actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,

--- a/Mimir.Worker/ActionHandler/PetStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/PetStateHandler.cs
@@ -79,11 +79,8 @@ public class PetStateHandler(IStateService stateService, MongoDbService store) :
             throw new ArgumentException($"Unknown actionType: {actionType}");
         }
 
-        Logger.Information("Handle pet_state, avatar: {AvatarAddress} ", avatarAddress);
-
         var petStateAddress = Nekoyume.Model.State.PetState.DeriveAddress(avatarAddress, petId);
         var petState = await StateGetter.GetPetState(petStateAddress, stoppingToken);
-
         await Store.UpsertStateDataManyAsync(
             CollectionNames.GetCollectionName<PetStateDocument>(),
             [new PetStateDocument(petStateAddress, petState)],

--- a/Mimir.Worker/ActionHandler/PetStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/PetStateHandler.cs
@@ -1,7 +1,6 @@
 using System.Text.RegularExpressions;
 using Bencodex.Types;
 using Lib9c.Models.Extensions;
-using Lib9c.Models.States;
 using Libplanet.Crypto;
 using Mimir.MongoDB;
 using Mimir.MongoDB.Bson;
@@ -12,14 +11,14 @@ using Serilog;
 
 namespace Mimir.Worker.ActionHandler;
 
-public class PetStateHandler(IStateService stateService, MongoDbService store)
-    : BaseActionHandler(
+public class PetStateHandler(IStateService stateService, MongoDbService store) :
+    BaseActionHandler(
         stateService,
         store,
         "^pet_enhancement[0-9]*$|^combination_equipment[0-9]*$|^rapid_combination[0-9]*$",
         Log.ForContext<PetStateHandler>())
 {
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -49,7 +48,7 @@ public class PetStateHandler(IStateService stateService, MongoDbService store)
             var pid = actionValues["pid"].ToNullableInteger();
             if (pid is null)
             {
-                return false;
+                return;
             }
 
             petId = pid.Value;
@@ -58,29 +57,19 @@ public class PetStateHandler(IStateService stateService, MongoDbService store)
         {
             avatarAddress = actionValues["avatarAddress"].ToAddress();
             var slotIndex = actionValues["slotIndex"].ToInteger();
-            AllCombinationSlotState allCombinationSlotState;
-            try
-            {
-                allCombinationSlotState = await StateGetter.GetAllCombinationSlotStateAsync(
-                    avatarAddress,
-                    stoppingToken);    
-            }
-            catch (Exception e)
-            {
-                Logger.Fatal(e, "Failed to get AllCombinationSlotState for avatar: {AvatarAddress}", avatarAddress);
-                return false;
-            }
+            var allCombinationSlotState = await StateGetter.GetAllCombinationSlotStateAsync(
+                avatarAddress,
+                stoppingToken);
 
             if (!allCombinationSlotState.CombinationSlots.TryGetValue(slotIndex, out var combinationSlotState))
             {
-                Logger.Fatal("CombinationSlotState not found for slotIndex: {SlotIndex}", slotIndex);
-                return false;
+                throw new InvalidOperationException($"CombinationSlotState not found for slotIndex: {slotIndex}");
             }
 
             if (combinationSlotState.PetId is null)
             {
                 // ignore
-                return true;
+                return;
             }
 
             petId = combinationSlotState.PetId.Value;
@@ -93,15 +82,12 @@ public class PetStateHandler(IStateService stateService, MongoDbService store)
         Logger.Information("Handle pet_state, avatar: {AvatarAddress} ", avatarAddress);
 
         var petStateAddress = Nekoyume.Model.State.PetState.DeriveAddress(avatarAddress, petId);
-        var petState = await StateGetter.GetPetState(petStateAddress);
+        var petState = await StateGetter.GetPetState(petStateAddress, stoppingToken);
 
         await Store.UpsertStateDataManyAsync(
             CollectionNames.GetCollectionName<PetStateDocument>(),
             [new PetStateDocument(petStateAddress, petState)],
             session,
-            stoppingToken
-        );
-
-        return true;
+            stoppingToken);
     }
 }

--- a/Mimir.Worker/ActionHandler/ProductsHandler.cs
+++ b/Mimir.Worker/ActionHandler/ProductsHandler.cs
@@ -22,6 +22,8 @@ public class ProductsHandler(IStateService stateService, MongoDbService store) :
 {
     protected override async Task<bool> TryHandleAction(
         long blockIndex,
+        Address signer,
+        IValue actionPlainValue,
         string actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,

--- a/Mimir.Worker/ActionHandler/ProductsHandler.cs
+++ b/Mimir.Worker/ActionHandler/ProductsHandler.cs
@@ -37,10 +37,6 @@ public class ProductsHandler(IStateService stateService, MongoDbService store) :
         }
 
         var avatarAddresses = GetAvatarAddresses(actionType, actionValues);
-        Logger.Information(
-            "Handle products, product, addresses: {AvatarAddresses}",
-            string.Join(", ", avatarAddresses));
-
         foreach (var avatarAddress in avatarAddresses)
         {
             var productsStateAddress = Nekoyume.Model.Market.ProductsState.DeriveAddress(avatarAddress);

--- a/Mimir.Worker/ActionHandler/ProductsHandler.cs
+++ b/Mimir.Worker/ActionHandler/ProductsHandler.cs
@@ -20,7 +20,7 @@ public class ProductsHandler(IStateService stateService, MongoDbService store) :
         "^register_product[0-9]*$|^cancel_product_registration[0-9]*$|^buy_product[0-9]*$|^re_register_product[0-9]*$",
         Log.ForContext<ProductsHandler>())
 {
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -44,17 +44,7 @@ public class ProductsHandler(IStateService stateService, MongoDbService store) :
         foreach (var avatarAddress in avatarAddresses)
         {
             var productsStateAddress = Nekoyume.Model.Market.ProductsState.DeriveAddress(avatarAddress);
-            ProductsState productsState;
-            try
-            {
-                productsState = await StateGetter.GetProductsState(avatarAddress, stoppingToken);
-            }
-            catch (Exception e)
-            {
-                Logger.Fatal(e, "Failed to get ProductsState for avatar address: {AvatarAddress}", avatarAddress);
-                return false;
-            }
-
+            var productsState = await StateGetter.GetProductsState(avatarAddress, stoppingToken);
             await SyncWrappedProductsStateAsync(
                 avatarAddress,
                 productsStateAddress,
@@ -62,8 +52,6 @@ public class ProductsHandler(IStateService stateService, MongoDbService store) :
                 session,
                 stoppingToken);
         }
-
-        return true;
     }
 
     private static List<Address> GetAvatarAddresses(string actionType, Dictionary actionValues)

--- a/Mimir.Worker/ActionHandler/RaidHandler.cs
+++ b/Mimir.Worker/ActionHandler/RaidHandler.cs
@@ -1,6 +1,7 @@
 using Bencodex.Types;
 using Lib9c.Models.Exceptions;
 using Lib9c.Models.Extensions;
+using Libplanet.Crypto;
 using Mimir.MongoDB;
 using Mimir.MongoDB.Bson;
 using Mimir.Worker.CollectionUpdaters;
@@ -19,6 +20,8 @@ public class RaidHandler(IStateService stateService, MongoDbService store)
 {
     protected override async Task<bool> TryHandleAction(
         long blockIndex,
+        Address signer,
+        IValue actionPlainValue,
         string actionType,
         IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,

--- a/Mimir.Worker/ActionHandler/RaidHandler.cs
+++ b/Mimir.Worker/ActionHandler/RaidHandler.cs
@@ -43,8 +43,6 @@ public class RaidHandler(IStateService stateService, MongoDbService store)
         var avatarAddress = d["a"].ToAddress();
         var equipmentIds = d["e"].ToList(StateExtensions.ToGuid);
         var costumeIds = d["c"].ToList(StateExtensions.ToGuid);
-        Logger.Information("Handle raid, avatar: {AvatarAddress}", avatarAddress);
-
         await ItemSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,

--- a/Mimir.Worker/ActionHandler/RequestPledgeHandler.cs
+++ b/Mimir.Worker/ActionHandler/RequestPledgeHandler.cs
@@ -17,7 +17,7 @@ public class RequestPledgeHandler(IStateService stateService, MongoDbService sto
 {
     private static readonly RequestPledge Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -35,6 +35,5 @@ public class RequestPledgeHandler(IStateService stateService, MongoDbService sto
             Action.RefillMead,
             session,
             stoppingToken);
-        return true;
     }
 }

--- a/Mimir.Worker/ActionHandler/RequestPledgeHandler.cs
+++ b/Mimir.Worker/ActionHandler/RequestPledgeHandler.cs
@@ -1,4 +1,4 @@
-using Libplanet.Action;
+using Bencodex.Types;
 using Libplanet.Crypto;
 using Mimir.Worker.CollectionUpdaters;
 using Mimir.Worker.Services;
@@ -13,35 +13,28 @@ public class RequestPledgeHandler(IStateService stateService, MongoDbService sto
         stateService,
         store,
         "^request_pledge[0-9]*$",
-        Log.ForContext<RequestPledgeHandler>()
-    )
+        Log.ForContext<RequestPledgeHandler>())
 {
+    private static readonly RequestPledge Action = new();
+
     protected override async Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
-        IAction action,
+        IValue actionPlainValue,
+        string actionType,
+        IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
-        if (action is not RequestPledge requestPledge)
-        {
-            return false;
-        }
-
-        Logger.Information(
-            "Handle request_pledge, request contracting with agent: {AgentAddress}",
-            requestPledge.AgentAddress);
-
+        Action.LoadPlainValue(actionPlainValue);
         await PledgeCollectionUpdater.UpsertAsync(
             Store,
-            requestPledge.AgentAddress.GetPledgeAddress(),
+            Action.AgentAddress.GetPledgeAddress(),
             signer,
             false,
-            requestPledge.RefillMead,
+            Action.RefillMead,
             session,
             stoppingToken);
-
         return true;
     }
 }

--- a/Mimir.Worker/ActionHandler/RequestPledgeHandler.cs
+++ b/Mimir.Worker/ActionHandler/RequestPledgeHandler.cs
@@ -15,8 +15,6 @@ public class RequestPledgeHandler(IStateService stateService, MongoDbService sto
         "^request_pledge[0-9]*$",
         Log.ForContext<RequestPledgeHandler>())
 {
-    private static readonly RequestPledge Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -26,13 +24,14 @@ public class RequestPledgeHandler(IStateService stateService, MongoDbService sto
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
+        var action = new RequestPledge();
+        action.LoadPlainValue(actionPlainValue);
         await PledgeCollectionUpdater.UpsertAsync(
             Store,
-            Action.AgentAddress.GetPledgeAddress(),
+            action.AgentAddress.GetPledgeAddress(),
             signer,
             false,
-            Action.RefillMead,
+            action.RefillMead,
             session,
             stoppingToken);
     }

--- a/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
@@ -76,19 +76,19 @@ public class RuneSlotStateHandler(IStateService stateService, MongoDbService sto
 
         if (Regex.IsMatch(actionType, "^hack_and_slash_sweep[0-9]*$"))
         {
-            HackAndSlash.LoadPlainValue(actionPlainValue);
+            HackAndSlashSweep.LoadPlainValue(actionPlainValue);
             return await TryProcessRuneSlotStateAsync(HackAndSlashSweep, session, stoppingToken);
         }
 
         if (Regex.IsMatch(actionType, "^join_arena[0-9]*$"))
         {
-            HackAndSlash.LoadPlainValue(actionPlainValue);
+            JoinArena.LoadPlainValue(actionPlainValue);
             return await TryProcessRuneSlotStateAsync(JoinArena, session, stoppingToken);
         }
 
         if (Regex.IsMatch(actionType, "^raid[0-9]*$"))
         {
-            HackAndSlash.LoadPlainValue(actionPlainValue);
+            Raid.LoadPlainValue(actionPlainValue);
             return await TryProcessRuneSlotStateAsync(Raid, session, stoppingToken);
         }
 
@@ -235,7 +235,7 @@ public class RuneSlotStateHandler(IStateService stateService, MongoDbService sto
     {
         if (Regex.IsMatch(actionType, "^unlock_rune_slot[0-9]*$"))
         {
-            BattleArena.LoadPlainValue(actionPlainValue);
+            UnlockRuneSlot.LoadPlainValue(actionPlainValue);
             return await TryProcessUnlockRuneSlotAsync(UnlockRuneSlot, session, stoppingToken);
         }
 

--- a/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
@@ -27,7 +27,7 @@ public class RuneSlotStateHandler(IStateService stateService, MongoDbService sto
 
     private static readonly BattleType[] BattleTypes = Enum.GetValues<BattleType>();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -38,16 +38,16 @@ public class RuneSlotStateHandler(IStateService stateService, MongoDbService sto
     {
         if (await TryProcessRuneSlotStateAsync(actionPlainValue, actionType, session, stoppingToken))
         {
-            return true;
+            return;
         }
 
         if (await TryProcessUnlockRuneSlotAsync(actionPlainValue, actionType, session, stoppingToken))
         {
-            return true;
+            return;
         }
 
-        // FIXME: throw exception.
-        return false;
+        throw new InvalidOperationException(
+            $"{nameof(RuneSlotStateHandler)} not support the action type: {actionType}");
     }
 
     private async Task<bool> TryProcessRuneSlotStateAsync(

--- a/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
@@ -17,14 +17,6 @@ public class RuneSlotStateHandler(IStateService stateService, MongoDbService sto
         "^(battle_arena[0-9]*|event_dungeon_battle[0-9]*|hack_and_slash[0-9]*|hack_and_slash_sweep[0-9]*|join_arena[0-9]*|raid[0-9]*|unlock_rune_slot[0-9]*)$",
         Log.ForContext<RuneSlotStateHandler>())
 {
-    private static readonly BattleArena BattleArena = new();
-    private static readonly EventDungeonBattle EventDungeonBattle = new();
-    private static readonly HackAndSlash HackAndSlash = new();
-    private static readonly HackAndSlashSweep HackAndSlashSweep = new();
-    private static readonly JoinArena JoinArena = new();
-    private static readonly Raid Raid = new();
-    private static readonly UnlockRuneSlot UnlockRuneSlot = new();
-
     private static readonly BattleType[] BattleTypes = Enum.GetValues<BattleType>();
 
     protected override async Task HandleAction(
@@ -58,38 +50,44 @@ public class RuneSlotStateHandler(IStateService stateService, MongoDbService sto
     {
         if (Regex.IsMatch(actionType, "^battle_arena[0-9]*$"))
         {
-            BattleArena.LoadPlainValue(actionPlainValue);
-            return await TryProcessRuneSlotStateAsync(BattleArena, session, stoppingToken);
+            var action = new BattleArena();
+            action.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(action, session, stoppingToken);
         }
 
         if (Regex.IsMatch(actionType, "^event_dungeon_battle[0-9]*$"))
         {
-            EventDungeonBattle.LoadPlainValue(actionPlainValue);
-            return await TryProcessRuneSlotStateAsync(EventDungeonBattle, session, stoppingToken);
+            var action = new EventDungeonBattle();
+            action.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(action, session, stoppingToken);
         }
 
         if (Regex.IsMatch(actionType, "^hack_and_slash[0-9]*$"))
         {
-            HackAndSlash.LoadPlainValue(actionPlainValue);
-            return await TryProcessRuneSlotStateAsync(HackAndSlash, session, stoppingToken);
+            var action = new HackAndSlash();
+            action.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(action, session, stoppingToken);
         }
 
         if (Regex.IsMatch(actionType, "^hack_and_slash_sweep[0-9]*$"))
         {
-            HackAndSlashSweep.LoadPlainValue(actionPlainValue);
-            return await TryProcessRuneSlotStateAsync(HackAndSlashSweep, session, stoppingToken);
+            var action = new HackAndSlashSweep();
+            action.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(action, session, stoppingToken);
         }
 
         if (Regex.IsMatch(actionType, "^join_arena[0-9]*$"))
         {
-            JoinArena.LoadPlainValue(actionPlainValue);
-            return await TryProcessRuneSlotStateAsync(JoinArena, session, stoppingToken);
+            var action = new JoinArena();
+            action.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(action, session, stoppingToken);
         }
 
         if (Regex.IsMatch(actionType, "^raid[0-9]*$"))
         {
-            Raid.LoadPlainValue(actionPlainValue);
-            return await TryProcessRuneSlotStateAsync(Raid, session, stoppingToken);
+            var action = new Raid();
+            action.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(action, session, stoppingToken);
         }
 
         return false;
@@ -235,8 +233,9 @@ public class RuneSlotStateHandler(IStateService stateService, MongoDbService sto
     {
         if (Regex.IsMatch(actionType, "^unlock_rune_slot[0-9]*$"))
         {
-            UnlockRuneSlot.LoadPlainValue(actionPlainValue);
-            return await TryProcessUnlockRuneSlotAsync(UnlockRuneSlot, session, stoppingToken);
+            var action = new UnlockRuneSlot();
+            action.LoadPlainValue(actionPlainValue);
+            return await TryProcessUnlockRuneSlotAsync(action, session, stoppingToken);
         }
 
         return false;

--- a/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
@@ -1,6 +1,5 @@
+using System.Text.RegularExpressions;
 using Bencodex.Types;
-using Lib9c.Abstractions;
-using Libplanet.Action;
 using Libplanet.Crypto;
 using Mimir.Worker.Services;
 using Mimir.Worker.CollectionUpdaters;
@@ -11,69 +10,97 @@ using Serilog;
 
 namespace Mimir.Worker.ActionHandler;
 
-public class RuneSlotStateHandler(IStateService stateService, MongoDbService store)
-    : BaseActionHandler(
+public class RuneSlotStateHandler(IStateService stateService, MongoDbService store) :
+    BaseActionHandler(
         stateService,
         store,
-        "^(battle_arena[0-9]*|event_dungeon_battle[0-9]*|join_arena[0-9]*|hack_and_slash[0-9]*|hack_and_slash_sweep[0-9]*|raid[0-9]*|unlock_rune_slot[0-9]*)$",
-        Log.ForContext<RuneSlotStateHandler>()
-    )
+        "^(battle_arena[0-9]*|event_dungeon_battle[0-9]*|hack_and_slash[0-9]*|hack_and_slash_sweep[0-9]*|join_arena[0-9]*|raid[0-9]*|unlock_rune_slot[0-9]*)$",
+        Log.ForContext<RuneSlotStateHandler>())
 {
+    private static readonly BattleArena BattleArena = new();
+    private static readonly EventDungeonBattle EventDungeonBattle = new();
+    private static readonly HackAndSlash HackAndSlash = new();
+    private static readonly HackAndSlashSweep HackAndSlashSweep = new();
+    private static readonly JoinArena JoinArena = new();
+    private static readonly Raid Raid = new();
+    private static readonly UnlockRuneSlot UnlockRuneSlot = new();
+
     private static readonly BattleType[] BattleTypes = Enum.GetValues<BattleType>();
 
     protected override async Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
-        IAction action,
+        IValue actionPlainValue,
+        string actionType,
+        IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
-        Logger.Information(
-            "RuneSlotStateHandler, address: {Signer}",
-            signer
-        );
-
-        if (await TryProcessRuneSlotStateAsync(action, session, stoppingToken))
+        if (await TryProcessRuneSlotStateAsync(actionPlainValue, actionType, session, stoppingToken))
         {
             return true;
         }
 
-        if (await TryProcessUnlockRuneSlotAsync(action, session, stoppingToken))
+        if (await TryProcessUnlockRuneSlotAsync(actionPlainValue, actionType, session, stoppingToken))
         {
             return true;
+        }
+
+        // FIXME: throw exception.
+        return false;
+    }
+
+    private async Task<bool> TryProcessRuneSlotStateAsync(
+        IValue actionPlainValue,
+        string actionType,
+        IClientSessionHandle? session = null,
+        CancellationToken stoppingToken = default)
+    {
+        if (Regex.IsMatch(actionType, "^battle_arena[0-9]*$"))
+        {
+            BattleArena.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(BattleArena, session, stoppingToken);
+        }
+
+        if (Regex.IsMatch(actionType, "^event_dungeon_battle[0-9]*$"))
+        {
+            EventDungeonBattle.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(EventDungeonBattle, session, stoppingToken);
+        }
+
+        if (Regex.IsMatch(actionType, "^hack_and_slash[0-9]*$"))
+        {
+            HackAndSlash.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(HackAndSlash, session, stoppingToken);
+        }
+
+        if (Regex.IsMatch(actionType, "^hack_and_slash_sweep[0-9]*$"))
+        {
+            HackAndSlash.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(HackAndSlashSweep, session, stoppingToken);
+        }
+
+        if (Regex.IsMatch(actionType, "^join_arena[0-9]*$"))
+        {
+            HackAndSlash.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(JoinArena, session, stoppingToken);
+        }
+
+        if (Regex.IsMatch(actionType, "^raid[0-9]*$"))
+        {
+            HackAndSlash.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(Raid, session, stoppingToken);
         }
 
         return false;
     }
 
     private async Task<bool> TryProcessRuneSlotStateAsync(
-        IAction action,
+        BattleArena action,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
-        (BattleType battleType, Address avatarAddress, IEnumerable<IValue>? runeSlotInfos)? tuple =
-            action switch
-            {
-                IBattleArenaV1 ba => (BattleType.Arena, ba.MyAvatarAddress, ba.RuneSlotInfos),
-                IEventDungeonBattleV2 edb
-                    => (BattleType.Adventure, edb.AvatarAddress, edb.RuneSlotInfos),
-                IJoinArenaV1 ja => (BattleType.Arena, ja.AvatarAddress, ja.RuneSlotInfos),
-                IHackAndSlashV10 has
-                    => (BattleType.Adventure, has.AvatarAddress, has.RuneSlotInfos),
-                IHackAndSlashSweepV3 hass
-                    => (BattleType.Adventure, hass.AvatarAddress, hass.RuneSlotInfos),
-                IRaidV2 r => (BattleType.Raid, r.AvatarAddress, r.RuneSlotInfos),
-                _ => null,
-            };
-        if (tuple is null)
-        {
-            return false;
-        }
-
-        var (battleType, avatarAddress, runeSlotInfos) = tuple.Value;
-        if (runeSlotInfos is null)
+        if (action.runeInfos is null)
         {
             // ignore
             return false;
@@ -82,37 +109,154 @@ public class RuneSlotStateHandler(IStateService stateService, MongoDbService sto
         await RuneSlotCollectionUpdater.UpdateAsync(
             StateService,
             Store,
-            battleType,
-            avatarAddress,
-            runeSlotInfos,
+            BattleType.Arena,
+            action.myAvatarAddress,
+            action.runeInfos,
             session,
-            stoppingToken
-        );
+            stoppingToken);
+        return true;
+    }
+
+    private async Task<bool> TryProcessRuneSlotStateAsync(
+        EventDungeonBattle action,
+        IClientSessionHandle? session = null,
+        CancellationToken stoppingToken = default)
+    {
+        if (action.RuneInfos is null)
+        {
+            // ignore
+            return false;
+        }
+
+        await RuneSlotCollectionUpdater.UpdateAsync(
+            StateService,
+            Store,
+            BattleType.Arena,
+            action.AvatarAddress,
+            action.RuneInfos,
+            session,
+            stoppingToken);
+        return true;
+    }
+
+    private async Task<bool> TryProcessRuneSlotStateAsync(
+        HackAndSlash action,
+        IClientSessionHandle? session = null,
+        CancellationToken stoppingToken = default)
+    {
+        if (action.RuneInfos is null)
+        {
+            // ignore
+            return false;
+        }
+
+        await RuneSlotCollectionUpdater.UpdateAsync(
+            StateService,
+            Store,
+            BattleType.Arena,
+            action.AvatarAddress,
+            action.RuneInfos,
+            session,
+            stoppingToken);
+        return true;
+    }
+
+    private async Task<bool> TryProcessRuneSlotStateAsync(
+        HackAndSlashSweep action,
+        IClientSessionHandle? session = null,
+        CancellationToken stoppingToken = default)
+    {
+        if (action.runeInfos is null)
+        {
+            // ignore
+            return false;
+        }
+
+        await RuneSlotCollectionUpdater.UpdateAsync(
+            StateService,
+            Store,
+            BattleType.Arena,
+            action.avatarAddress,
+            action.runeInfos,
+            session,
+            stoppingToken);
+        return true;
+    }
+
+    private async Task<bool> TryProcessRuneSlotStateAsync(
+        JoinArena action,
+        IClientSessionHandle? session = null,
+        CancellationToken stoppingToken = default)
+    {
+        if (action.runeInfos is null)
+        {
+            // ignore
+            return false;
+        }
+
+        await RuneSlotCollectionUpdater.UpdateAsync(
+            StateService,
+            Store,
+            BattleType.Arena,
+            action.avatarAddress,
+            action.runeInfos,
+            session,
+            stoppingToken);
+        return true;
+    }
+
+    private async Task<bool> TryProcessRuneSlotStateAsync(
+        Raid action,
+        IClientSessionHandle? session = null,
+        CancellationToken stoppingToken = default)
+    {
+        if (action.RuneInfos is null)
+        {
+            // ignore
+            return false;
+        }
+
+        await RuneSlotCollectionUpdater.UpdateAsync(
+            StateService,
+            Store,
+            BattleType.Arena,
+            action.AvatarAddress,
+            action.RuneInfos,
+            session,
+            stoppingToken);
         return true;
     }
 
     private async Task<bool> TryProcessUnlockRuneSlotAsync(
-        IAction action,
+        IValue actionPlainValue,
+        string actionType,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
-        if (action is not IUnlockRuneSlotV1 unlockRuneSlot)
+        if (Regex.IsMatch(actionType, "^unlock_rune_slot[0-9]*$"))
         {
-            return false;
+            BattleArena.LoadPlainValue(actionPlainValue);
+            return await TryProcessUnlockRuneSlotAsync(UnlockRuneSlot, session, stoppingToken);
         }
 
+        return false;
+    }
+
+    private async Task<bool> TryProcessUnlockRuneSlotAsync(
+        UnlockRuneSlot action,
+        IClientSessionHandle? session = null,
+        CancellationToken stoppingToken = default)
+    {
         foreach (var battleType in BattleTypes)
         {
             await RuneSlotCollectionUpdater.UpdateAsync(
                 StateService,
                 Store,
                 battleType,
-                unlockRuneSlot.AvatarAddress,
-                unlockRuneSlot.SlotIndex,
+                action.AvatarAddress,
+                action.SlotIndex,
                 session,
-                stoppingToken
-            );
+                stoppingToken);
         }
 
         return true;

--- a/Mimir.Worker/ActionHandler/StakeHandler.cs
+++ b/Mimir.Worker/ActionHandler/StakeHandler.cs
@@ -1,37 +1,34 @@
-using Lib9c.Abstractions;
-using Libplanet.Action;
+using Bencodex.Types;
 using Libplanet.Crypto;
 using Mimir.Worker.CollectionUpdaters;
 using Mimir.Worker.Services;
 using MongoDB.Driver;
+using Nekoyume.Action;
 using Serilog;
 
 namespace Mimir.Worker.ActionHandler;
 
-public class StakeHandler(IStateService stateService, MongoDbService store)
-    : BaseActionHandler(stateService, store, "^stake[0-9]*$", Log.ForContext<StakeHandler>())
+public class StakeHandler(IStateService stateService, MongoDbService store) :
+    BaseActionHandler(stateService, store, "^stake[0-9]*$", Log.ForContext<StakeHandler>())
 {
+    private static readonly Stake Action = new();
+
     protected override async Task<bool> TryHandleAction(
         long blockIndex,
         Address signer,
-        IAction action,
+        IValue actionPlainValue,
+        string actionType,
+        IValue? actionPlainValueInternal,
         IClientSessionHandle? session = null,
-        CancellationToken stoppingToken = default
-    )
+        CancellationToken stoppingToken = default)
     {
-        if (action is not IStakeV1)
-        {
-            return false;
-        }
-
+        Action.LoadPlainValue(actionPlainValue);
         await StakeCollectionUpdater.UpdateAsync(
             StateService,
             Store,
             signer,
             session,
-            stoppingToken
-        );
-
+            stoppingToken);
         return true;
     }
 }

--- a/Mimir.Worker/ActionHandler/StakeHandler.cs
+++ b/Mimir.Worker/ActionHandler/StakeHandler.cs
@@ -13,7 +13,7 @@ public class StakeHandler(IStateService stateService, MongoDbService store) :
 {
     private static readonly Stake Action = new();
 
-    protected override async Task<bool> TryHandleAction(
+    protected override async Task HandleAction(
         long blockIndex,
         Address signer,
         IValue actionPlainValue,
@@ -29,6 +29,5 @@ public class StakeHandler(IStateService stateService, MongoDbService store) :
             signer,
             session,
             stoppingToken);
-        return true;
     }
 }

--- a/Mimir.Worker/ActionHandler/StakeHandler.cs
+++ b/Mimir.Worker/ActionHandler/StakeHandler.cs
@@ -11,8 +11,6 @@ namespace Mimir.Worker.ActionHandler;
 public class StakeHandler(IStateService stateService, MongoDbService store) :
     BaseActionHandler(stateService, store, "^stake[0-9]*$", Log.ForContext<StakeHandler>())
 {
-    private static readonly Stake Action = new();
-
     protected override async Task HandleAction(
         long blockIndex,
         Address signer,
@@ -22,7 +20,8 @@ public class StakeHandler(IStateService stateService, MongoDbService store) :
         IClientSessionHandle? session = null,
         CancellationToken stoppingToken = default)
     {
-        Action.LoadPlainValue(actionPlainValue);
+        var action = new Stake();
+        action.LoadPlainValue(actionPlainValue);
         await StakeCollectionUpdater.UpdateAsync(
             StateService,
             Store,

--- a/Mimir.Worker/Client/Models.cs
+++ b/Mimir.Worker/Client/Models.cs
@@ -68,7 +68,7 @@ public class GetTransactionsResponse
 public class TransactionResponse
 {
     [JsonPropertyName("ncTransactions")]
-    public List<NcTransaction> NCTransactions { get; set; }
+    public List<NcTransaction?> NCTransactions { get; set; }
 }
 
 public class NcTransaction
@@ -83,7 +83,7 @@ public class NcTransaction
     public string SerializedPayload { get; set; }
 
     [JsonPropertyName("actions")]
-    public List<Action> Actions { get; set; }
+    public List<Action?> Actions { get; set; }
 }
 
 public class Action

--- a/Mimir.Worker/Constants/PlanetType.cs
+++ b/Mimir.Worker/Constants/PlanetType.cs
@@ -17,6 +17,7 @@ public class PlanetType
     {
         return planetType switch
         {
+            null => throw new ArgumentNullException(nameof(planetType)),
             "odin" => new PlanetType("odin"),
             "heimdall" => new PlanetType("heimdall"),
             _ => throw new ArgumentException($"Not expected planetType. {planetType}")

--- a/Mimir.Worker/Handler/ActionPointStateHandler.cs
+++ b/Mimir.Worker/Handler/ActionPointStateHandler.cs
@@ -3,7 +3,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class ActionPointStateHandler : IStateHandler
+public class ActionPointStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Handler/AddressHandlerMappings.cs
+++ b/Mimir.Worker/Handler/AddressHandlerMappings.cs
@@ -8,7 +8,7 @@ namespace Mimir.Worker.Handler;
 
 public static class AddressHandlerMappings
 {
-    public static readonly Dictionary<Address, IStateHandler> HandlerMappings = new();
+    public static readonly Dictionary<Address, IStateDiffHandler> HandlerMappings = new();
 
     public static readonly Currency OdinNCGCurrency = Currency.Legacy(
         "NCG",

--- a/Mimir.Worker/Handler/AgentStateHandler.cs
+++ b/Mimir.Worker/Handler/AgentStateHandler.cs
@@ -5,7 +5,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class AgentStateHandler : IStateHandler
+public class AgentStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Handler/AllCombinationSlotStateHandler.cs
+++ b/Mimir.Worker/Handler/AllCombinationSlotStateHandler.cs
@@ -3,7 +3,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class AllCombinationSlotStateHandler : IStateHandler
+public class AllCombinationSlotStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context) =>
         new AllCombinationSlotStateDocument(context.Address, new AllCombinationSlotState(context.RawState));

--- a/Mimir.Worker/Handler/AllRuneStateHandler.cs
+++ b/Mimir.Worker/Handler/AllRuneStateHandler.cs
@@ -3,7 +3,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class AllRuneStateHandler : IStateHandler
+public class AllRuneStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Handler/AvatarStateHandler.cs
+++ b/Mimir.Worker/Handler/AvatarStateHandler.cs
@@ -3,7 +3,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class AvatarStateHandler : IStateHandler
+public class AvatarStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Handler/BalanceHandler.cs
+++ b/Mimir.Worker/Handler/BalanceHandler.cs
@@ -4,7 +4,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public record BalanceHandler(Currency Currency) : IStateHandler
+public record BalanceHandler(Currency Currency) : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Handler/CollectionStateHandler.cs
+++ b/Mimir.Worker/Handler/CollectionStateHandler.cs
@@ -3,7 +3,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class CollectionStateHandler : IStateHandler
+public class CollectionStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Handler/DailyRewardStateHandler.cs
+++ b/Mimir.Worker/Handler/DailyRewardStateHandler.cs
@@ -3,7 +3,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class DailyRewardStateHandler : IStateHandler
+public class DailyRewardStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Handler/IStateDiffHandler.cs
+++ b/Mimir.Worker/Handler/IStateDiffHandler.cs
@@ -2,7 +2,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public interface IStateHandler
+public interface IStateDiffHandler
 {
     MimirBsonDocument ConvertToDocument(StateDiffContext context);
 }

--- a/Mimir.Worker/Handler/InventoryStateHandler.cs
+++ b/Mimir.Worker/Handler/InventoryStateHandler.cs
@@ -3,7 +3,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class InventoryStateHandler : IStateHandler
+public class InventoryStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Handler/WorldInformationStateHandler.cs
+++ b/Mimir.Worker/Handler/WorldInformationStateHandler.cs
@@ -3,7 +3,7 @@ using Mimir.MongoDB.Bson;
 
 namespace Mimir.Worker.Handler;
 
-public class WorldInformationStateHandler : IStateHandler
+public class WorldInformationStateHandler : IStateDiffHandler
 {
     public MimirBsonDocument ConvertToDocument(StateDiffContext context)
     {

--- a/Mimir.Worker/Initializer/TableSheetInitializer.cs
+++ b/Mimir.Worker/Initializer/TableSheetInitializer.cs
@@ -1,8 +1,8 @@
 using Mimir.MongoDB;
 using Mimir.MongoDB.Bson;
+using Mimir.Worker.ActionHandler;
 using Mimir.Worker.Services;
 using Mimir.Worker.Util;
-using Mimir.Worker.ActionHandler;
 using MongoDB.Bson;
 using Serilog;
 

--- a/Mimir.Worker/Mimir.Worker.csproj
+++ b/Mimir.Worker/Mimir.Worker.csproj
@@ -28,8 +28,4 @@
     <ProjectReference Include="..\Lib9c.Models\Lib9c.Models.csproj" />
     <ProjectReference Include="..\Mimir.MongoDB\Mimir.MongoDB.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Models\State\" />
-  </ItemGroup>
 </Project>

--- a/Mimir.Worker/Poller/DiffPoller/DiffConsumer.cs
+++ b/Mimir.Worker/Poller/DiffPoller/DiffConsumer.cs
@@ -81,7 +81,7 @@ public class DiffConsumer
     }
 
     private async Task ProcessStateDiff(
-        IStateHandler handler,
+        IStateDiffHandler handler,
         Address accountAddress,
         GetAccountDiffsResponse diffResponse,
         CancellationToken stoppingToken

--- a/Mimir.Worker/Poller/TxPoller.cs
+++ b/Mimir.Worker/Poller/TxPoller.cs
@@ -43,6 +43,7 @@ public class TxPoller : IBlockPoller
             // Pledge
             new ApprovePledgeHandler(stateService, dbService),
             new EndPledgeHandler(stateService, dbService),
+            new RequestPledgeHandler(stateService, dbService),
             // World
             new HackAndSlashHandler(stateService, dbService),
             new HackAndSlashSweepHandler(stateService, dbService),

--- a/Mimir.Worker/Poller/TxPoller.cs
+++ b/Mimir.Worker/Poller/TxPoller.cs
@@ -184,6 +184,7 @@ public class TxPoller : IBlockPoller
                     var task = handler.TryHandleAction(
                         blockIndex,
                         signer,
+                        action.PlainValue,
                         actionType,
                         actionPlainValueInternal,
                         stoppingToken: cancellationToken);

--- a/Mimir.Worker/Poller/TxPoller.cs
+++ b/Mimir.Worker/Poller/TxPoller.cs
@@ -40,6 +40,8 @@ public class TxPoller : IBlockPoller
         _handlers =
         [
             new PatchTableHandler(stateService, dbService),
+            // Pledge
+            new ApprovePledgeHandler(stateService, dbService),
             // World
             new HackAndSlashHandler(stateService, dbService),
             new HackAndSlashSweepHandler(stateService, dbService),

--- a/Mimir.Worker/Poller/TxPoller.cs
+++ b/Mimir.Worker/Poller/TxPoller.cs
@@ -42,6 +42,7 @@ public class TxPoller : IBlockPoller
             new PatchTableHandler(stateService, dbService),
             // Pledge
             new ApprovePledgeHandler(stateService, dbService),
+            new EndPledgeHandler(stateService, dbService),
             // World
             new HackAndSlashHandler(stateService, dbService),
             new HackAndSlashSweepHandler(stateService, dbService),

--- a/Mimir.Worker/Poller/TxPoller.cs
+++ b/Mimir.Worker/Poller/TxPoller.cs
@@ -1,12 +1,10 @@
 using Bencodex;
 using Bencodex.Types;
 using Libplanet.Crypto;
-using Libplanet.Types.Tx;
 using Mimir.MongoDB;
 using Mimir.MongoDB.Bson;
 using Mimir.Worker.ActionHandler;
 using Mimir.Worker.Client;
-using Mimir.Worker.Handler;
 using Mimir.Worker.Services;
 using Nekoyume.Action.Loader;
 using Serilog;
@@ -168,7 +166,7 @@ public class TxPoller : IBlockPoller
             .Select(tx =>
                 (
                     TxId: tx!.Id,
-                    Signer: new Address(tx!.Signer),
+                    Signer: new Address(tx.Signer),
                     actions: tx.Actions
                         .Where(action => action is not null)
                         .Select(action => ActionLoader.LoadAction(
@@ -258,7 +256,7 @@ public class TxPoller : IBlockPoller
         return (actionType, actionPlainValueInternal);
     }
 
-    public async Task<long> GetSyncedBlockIndex(string collectionName, CancellationToken stoppingToken)
+    private async Task<long> GetSyncedBlockIndex(string collectionName, CancellationToken stoppingToken)
     {
         try
         {


### PR DESCRIPTION
This pull request resolve #359.

- Rename `IStateHandler` to `IStateDiffHandler`.
- Refactor `BaseActionHandler`.
    - Fix `BaseActionHandler.TryHandleAction` to `HandleAction`. 
- Logging in `BaseActionHandler`.
- Re-implement and register `ApprovePledgeHandler`, `EndPledgeHandler`, `RequestPledgeHandler`.
- Re-implement `BattleArenaHandler`, `EventDungeonBattleHandler`, `HackAndSlashHandler`, `HackAndSlashSweepHandler`, `JoinArenaHandler`, `RuneSlotStateHandler`, `StakeHandler`.
- Set `nullable` to a couple of GraphQL schema.
