### PR TITLE
feat: add "runes" graphQL query

### DIFF
--- a/Lib9c.Models/States/AllRuneState.cs
+++ b/Lib9c.Models/States/AllRuneState.cs
@@ -13,7 +13,7 @@ namespace Lib9c.Models.States;
 [BsonIgnoreExtraElements]
 public record AllRuneState : IBencodable
 {
-    public Dictionary<int, RuneState> Runes { get; }
+    public Dictionary<int, RuneState> Runes { get; init; }
 
     [BsonIgnore, GraphQLIgnore, JsonIgnore]
     public IValue Bencoded => new List(Runes

--- a/Mimir.MongoDB/CollectionNames.cs
+++ b/Mimir.MongoDB/CollectionNames.cs
@@ -102,7 +102,7 @@ namespace Mimir.MongoDB
             // CollectionAndStateTypeMappings.Add(typeof(SeasonInfoDocument), "adventure_boss_season_info");
             CollectionAndStateTypeMappings.Add(typeof(AgentDocument), "agent");
             CollectionAndStateTypeMappings.Add(typeof(AllCombinationSlotStateDocument), "all_combination_slot");
-            // CollectionAndStateTypeMappings.Add(typeof(AllRuneDocument), "all_rune");
+            CollectionAndStateTypeMappings.Add(typeof(AllRuneDocument), "all_rune");
             CollectionAndStateTypeMappings.Add(typeof(AvatarDocument), "avatar");
             CollectionAndStateTypeMappings.Add(typeof(ArenaDocument), "arena");
             CollectionAndStateTypeMappings.Add(typeof(DailyRewardDocument), "daily_reward");

--- a/Mimir.MongoDB/CollectionNames.cs
+++ b/Mimir.MongoDB/CollectionNames.cs
@@ -8,12 +8,12 @@ namespace Mimir.MongoDB
 {
     public static class CollectionNames
     {
-        public static readonly Currency OdinNCGCurrency = Currency.Legacy(
+        private static readonly Currency OdinNCGCurrency = Currency.Legacy(
             "NCG",
             2,
             new Address("0x47d082a115c63e7b58b1532d20e631538eafadde"));
 
-        public static readonly Currency HeimdallNCGCurrency = Currency.Legacy(
+        private static readonly Currency HeimdallNCGCurrency = Currency.Legacy(
             "NCG",
             2,
             null);
@@ -23,14 +23,24 @@ namespace Mimir.MongoDB
 
         static CollectionNames()
         {
+            RegisterCollectionAndAddressMappings();
+            RegisterCollectionAndAddressMappingsForCurrencies();
+            RegisterCollectionAndStateMappings();
+        }
+
+        private static Address GetAccountAddress(Currency currency) => new(currency.Hash.ToByteArray());
+
+        /// <summary>
+        /// Register MongoDB collections for various related address.
+        /// </summary>
+        private static void RegisterCollectionAndAddressMappings()
+        {
+            // Sort in alphabetical order.
+            CollectionAndAddressMappings.Add(Addresses.ActionPoint, "action_point");
             CollectionAndAddressMappings.Add(Addresses.Agent, "agent");
             CollectionAndAddressMappings.Add(Addresses.Avatar, "avatar");
-            CollectionAndAddressMappings.Add(Addresses.ActionPoint, "action_point");
             CollectionAndAddressMappings.Add(Addresses.DailyReward, "daily_reward");
             CollectionAndAddressMappings.Add(Addresses.Inventory, "inventory");
-            CollectionAndAddressMappings.Add(Addresses.WorldInformation, "world_information");
-            // CollectionAndAddressMappings.Add(Addresses.QuestList, "quest_list");
-            CollectionAndAddressMappings.Add(Addresses.RuneState, "all_rune");
             CollectionAndAddressMappings.Add(Addresses.Collection, "collection");
             // CollectionAndAddressMappings.Add(Addresses.BountyBoard, "adventure_boss_bounty_board");
             // CollectionAndAddressMappings.Add(Addresses.ExploreBoard, "adventure_boss_explore_board");
@@ -39,67 +49,80 @@ namespace Mimir.MongoDB
             // CollectionAndAddressMappings.Add(Addresses.AdventureBoss, "adventure_boss_season_info");
             CollectionAndAddressMappings.Add(Addresses.CombinationSlot, "all_combination_slot");
 
+            // CollectionAndAddressMappings.Add(Addresses.QuestList, "quest_list");
+            CollectionAndAddressMappings.Add(Addresses.RuneState, "all_rune");
+            CollectionAndAddressMappings.Add(Addresses.WorldInformation, "world_information");
+        }
+
+        /// <summary>
+        /// Register MongoDB collections for various related currency's address.
+        /// </summary>
+        private static void RegisterCollectionAndAddressMappingsForCurrencies()
+        {
+            // Sort in alphabetical order.
+            CollectionAndAddressMappings.Add(GetAccountAddress(Currencies.Crystal), "balance_crystal");
+            CollectionAndAddressMappings.Add(GetAccountAddress(Currencies.Garage), "balance_garage");
+            CollectionAndAddressMappings.Add(GetAccountAddress(Currencies.Mead), "balance_mead");
+
+            // FIXME: NCG currency should be mapped only once. Consider planet type of configuration.
+            //        Getting NCG information in configurations might be better than trying to distinguish between Odin
+            //        and Heimdall here.
+            CollectionAndAddressMappings.Add(GetAccountAddress(OdinNCGCurrency), "balance_ncg");
+            CollectionAndAddressMappings.Add(GetAccountAddress(HeimdallNCGCurrency), "balance_ncg");
+
+            // Runes. Sort in alphabetical order.
             CollectionAndAddressMappings.Add(
-                new Address(OdinNCGCurrency.Hash.ToByteArray()),
-                "balance_ncg");
-            CollectionAndAddressMappings.Add(
-                new Address(HeimdallNCGCurrency.Hash.ToByteArray()),
-                "balance_ncg");
-            CollectionAndAddressMappings.Add(
-                new Address(Currencies.Crystal.Hash.ToByteArray()),
-                "balance_crystal");
-            CollectionAndAddressMappings.Add(
-                new Address(Currencies.StakeRune.Hash.ToByteArray()),
-                "balance_stake_rune");
-            CollectionAndAddressMappings.Add(
-                new Address(Currencies.DailyRewardRune.Hash.ToByteArray()),
-                "balance_daily_reward_rune");
-            CollectionAndAddressMappings.Add(
-                new Address(Currencies.Garage.Hash.ToByteArray()),
-                "balance_garage");
-            CollectionAndAddressMappings.Add(
-                new Address(Currencies.Mead.Hash.ToByteArray()),
-                "balance_mead");
-            CollectionAndAddressMappings.Add(
-                new Address(Currencies.FreyaBlessingRune.Hash.ToByteArray()),
+                GetAccountAddress(Currencies.FreyaBlessingRune),
                 "balance_freya_blessing_rune");
             CollectionAndAddressMappings.Add(
-                new Address(Currencies.FreyaLiberationRune.Hash.ToByteArray()),
+                GetAccountAddress(Currencies.FreyaLiberationRune),
                 "balance_freya_liberation_rune");
+            CollectionAndAddressMappings.Add(GetAccountAddress(Currencies.StakeRune), "balance_stake_rune");
             CollectionAndAddressMappings.Add(
-                new Address(Currencies.OdinWeaknessRune.Hash.ToByteArray()),
-                "balance_weakness_rune");
-            CollectionAndAddressMappings.Add(
-                new Address(Currencies.OdinWisdomRune.Hash.ToByteArray()),
-                "balance_wisdom_rune");
-            CollectionAndStateTypeMappings.Add(typeof(MetadataDocument), "metadata");
-            CollectionAndStateTypeMappings.Add(typeof(SheetDocument), "table_sheet");
-            CollectionAndStateTypeMappings.Add(typeof(AgentDocument), "agent");
-            CollectionAndStateTypeMappings.Add(typeof(AvatarDocument), "avatar");
+                GetAccountAddress(Currencies.DailyRewardRune),
+                "balance_daily_reward_rune");
+            CollectionAndAddressMappings.Add(GetAccountAddress(Currencies.OdinWeaknessRune), "balance_weakness_rune");
+            CollectionAndAddressMappings.Add(GetAccountAddress(Currencies.OdinWisdomRune), "balance_wisdom_rune");
+
+            // Soul stones. Sort in alphabetical order.
+            // Register here.
+        }
+
+        /// <summary>
+        /// Register MongoDB collections for various related documents.
+        /// </summary>
+        private static void RegisterCollectionAndStateMappings()
+        {
+            // Sort in alphabetical order. 
             CollectionAndStateTypeMappings.Add(typeof(ActionPointDocument), "action_point");
-            CollectionAndStateTypeMappings.Add(typeof(DailyRewardDocument), "daily_reward");
-            CollectionAndStateTypeMappings.Add(typeof(InventoryDocument), "inventory");
+            // CollectionAndStateTypeMappings.Add(typeof(BountyBoardDocument), "adventure_boss_bounty_board");
+            // CollectionAndStateTypeMappings.Add(typeof(ExplorerDocument), "adventure_boss_explorer");
+            // CollectionAndStateTypeMappings.Add(typeof(ExploreBoardDocument), "adventure_boss_explore_board");
+            // CollectionAndStateTypeMappings.Add(typeof(ExplorerListDocument), "adventure_boss_explorer_list");
+            // CollectionAndStateTypeMappings.Add(typeof(SeasonInfoDocument), "adventure_boss_season_info");
+            CollectionAndStateTypeMappings.Add(typeof(AgentDocument), "agent");
+            CollectionAndStateTypeMappings.Add(typeof(AllCombinationSlotStateDocument), "all_combination_slot");
+            // CollectionAndStateTypeMappings.Add(typeof(AllRuneDocument), "all_rune");
+            CollectionAndStateTypeMappings.Add(typeof(AvatarDocument), "avatar");
             CollectionAndStateTypeMappings.Add(typeof(ArenaDocument), "arena");
+            CollectionAndStateTypeMappings.Add(typeof(DailyRewardDocument), "daily_reward");
+            CollectionAndStateTypeMappings.Add(typeof(ItemSlotDocument), "item_slot");
+            CollectionAndStateTypeMappings.Add(typeof(InventoryDocument), "inventory");
+            CollectionAndStateTypeMappings.Add(typeof(MetadataDocument), "metadata");
+            CollectionAndStateTypeMappings.Add(typeof(PetStateDocument), "pet_state");
+            CollectionAndStateTypeMappings.Add(typeof(PledgeDocument), "pledge");
             CollectionAndStateTypeMappings.Add(typeof(ProductsStateDocument), "products");
             CollectionAndStateTypeMappings.Add(typeof(ProductDocument), "product");
             // CollectionAndStateTypeMappings.Add(typeof(QuestListDocument), "quest_list");
-            CollectionAndStateTypeMappings.Add(typeof(WorldInformationDocument), "world_information");
-            CollectionAndStateTypeMappings.Add(typeof(ItemSlotDocument), "item_slot");
+            CollectionAndStateTypeMappings.Add(typeof(RaiderStateDocument), "raider");
             CollectionAndStateTypeMappings.Add(typeof(RuneSlotDocument), "rune_slot");
+            CollectionAndStateTypeMappings.Add(typeof(SheetDocument), "table_sheet");
             CollectionAndStateTypeMappings.Add(typeof(WorldBossStateDocument), "world_boss");
             CollectionAndStateTypeMappings.Add(
                 typeof(WorldBossKillRewardRecordDocument),
                 "world_boss_kill_reward_record");
-            CollectionAndStateTypeMappings.Add(typeof(RaiderStateDocument), "raider");
+            CollectionAndStateTypeMappings.Add(typeof(WorldInformationDocument), "world_information");
             CollectionAndStateTypeMappings.Add(typeof(StakeDocument), "stake");
-            CollectionAndStateTypeMappings.Add(typeof(AllCombinationSlotStateDocument), "all_combination_slot");
-            CollectionAndStateTypeMappings.Add(typeof(PetStateDocument), "pet_state");
-            // CollectionAndStateTypeMappings.Add(typeof(BountyBoardDocument), "adventure_boss_bounty_board");
-            // CollectionAndStateTypeMappings.Add(typeof(ExploreBoardDocument), "adventure_boss_explore_board");
-            // CollectionAndStateTypeMappings.Add(typeof(ExplorerListDocument), "adventure_boss_explorer_list");
-            // CollectionAndStateTypeMappings.Add(typeof(ExplorerDocument), "adventure_boss_explorer");
-            // CollectionAndStateTypeMappings.Add(typeof(SeasonInfoDocument), "adventure_boss_season_info");
-            CollectionAndStateTypeMappings.Add(typeof(PledgeDocument), "pledge");
         }
 
         public static string GetCollectionName<T>()

--- a/Mimir.MongoDB/Repositories/AllRuneRepository.cs
+++ b/Mimir.MongoDB/Repositories/AllRuneRepository.cs
@@ -8,17 +8,17 @@ namespace Mimir.MongoDB.Repositories;
 
 public class AllRuneRepository(MongoDbService dbService)
 {
-    public Task<AllRuneDocument> GetByAddressAsync(Address avatarAddress)
+    public async Task<AllRuneDocument> GetByAddressAsync(Address address)
     {
         var collectionName = CollectionNames.GetCollectionName<AllRuneDocument>();
         var collection = dbService.GetCollection<AllRuneDocument>(collectionName);
-        var filter = Builders<AllRuneDocument>.Filter.Eq("Address", avatarAddress.ToHex());
-        var document = collection.Find(filter).FirstOrDefaultAsync();
+        var filter = Builders<AllRuneDocument>.Filter.Eq("Address", address.ToHex());
+        var document = await collection.Find(filter).FirstOrDefaultAsync();
         if (document is null)
         {
             throw new DocumentNotFoundInMongoCollectionException(
                 collection.CollectionNamespace.CollectionName,
-                $"'Address' equals to '{avatarAddress.ToHex()}'");
+                $"'Address' equals to '{address.ToHex()}'");
         }
 
         return document;

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -19,16 +19,6 @@ namespace Mimir.GraphQL.Queries;
 public class Query
 {
     /// <summary>
-    /// Get all combination slot states for a specific avatar address.
-    /// </summary>
-    /// <param name="avatarAddress">The address of the avatar</param>
-    /// <returns>All combination slot states for the specified avatar address.</returns>
-    public async Task<AllCombinationSlotState> GetAllCombinationSlotsAsync(
-        Address avatarAddress,
-        [Service] AllCombinationSlotStateRepository repo) =>
-        (await repo.GetByAddressAsync(avatarAddress)).Object;
-
-    /// <summary>
     /// Get an action point by address.
     /// </summary>
     /// <param name="address">The address of the avatar.</param>
@@ -83,6 +73,16 @@ public class Query
 
         throw new GraphQLRequestException("Either currency or currencyTicker must be provided.");
     }
+
+    /// <summary>
+    /// Get combination slot states for a specific avatar address.
+    /// </summary>
+    /// <param name="avatarAddress">The address of the avatar</param>
+    /// <returns>Combination slot states for the specified avatar address.</returns>
+    public async Task<Dictionary<int, CombinationSlotState>> GetCombinationSlotsAsync(
+        Address avatarAddress,
+        [Service] AllCombinationSlotStateRepository repo) =>
+        (await repo.GetByAddressAsync(avatarAddress)).Object.CombinationSlots;
 
     /// <summary>
     /// Get the daily reward received block index by address.

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -15,15 +15,47 @@ using Nekoyume.TableData;
 
 namespace Mimir.GraphQL.Queries;
 
+// NOTE: Sort methods in alphabetical order.
 public class Query
 {
     /// <summary>
-    /// Get metadata by collection name.
+    /// Get all combination slot states for a specific avatar address.
     /// </summary>
-    /// <param name="collectionName">The name of the collection.</param>
-    /// <returns>The metadata</returns>
-    public async Task<MetadataDocument> GetMetadataAsync(string collectionName, [Service] MetadataRepository repo) =>
-        await repo.GetByCollectionAsync(collectionName);
+    /// <param name="avatarAddress">The address of the avatar</param>
+    /// <returns>All combination slot states for the specified avatar address.</returns>
+    public async Task<AllCombinationSlotState> GetAllCombinationSlotsAsync(
+        Address avatarAddress,
+        [Service] AllCombinationSlotStateRepository repo) =>
+        (await repo.GetByAddressAsync(avatarAddress)).Object;
+
+    /// <summary>
+    /// Get an action point by address.
+    /// </summary>
+    /// <param name="address">The address of the avatar.</param>
+    /// <returns>The action point.</returns>
+    public async Task<int> GetActionPointAsync(Address address, [Service] ActionPointRepository repo) =>
+        (await repo.GetByAddressAsync(address)).Object;
+
+    /// <summary>
+    /// Get an agent state by address.
+    /// </summary>
+    /// <param name="address">The address of the agent.</param>
+    /// <returns>The agent state</returns>
+    public async Task<AgentState> GetAgentAsync(Address address, [Service] AgentRepository repo) =>
+        (await repo.GetByAddressAsync(address)).Object;
+
+    /// <summary>
+    /// Get arena sub-fields.
+    /// </summary>
+    public ArenaObject GetArena() => new();
+
+    /// <summary>
+    /// Get an avatar state by address.
+    /// </summary>
+    /// <param name="address">The address of the avatar.</param>
+    /// <returns>The avatar state</returns>
+    public async Task<AvatarState> GetAvatarAsync(Address address, [Service] AvatarRepository repo) =>
+        (await repo.GetByAddressAsync(address)).Object;
 
     /// <summary>
     /// Get the balance of a specific currency for a given address.
@@ -53,44 +85,6 @@ public class Query
     }
 
     /// <summary>
-    /// Get the pledge state for a given agent address.
-    /// </summary>
-    public async Task<PledgeDocument> GetPledgeAsync(Address agentAddress, [Service] PledgeRepository repo) =>
-        await repo.GetByAddressAsync(agentAddress.GetPledgeAddress());
-
-    /// <summary>
-    /// Get an agent state by address.
-    /// </summary>
-    /// <param name="address">The address of the agent.</param>
-    /// <returns>The agent state</returns>
-    public async Task<AgentState> GetAgentAsync(Address address, [Service] AgentRepository repo) =>
-        (await repo.GetByAddressAsync(address)).Object;
-
-    /// <summary>
-    /// Get an avatar state by address.
-    /// </summary>
-    /// <param name="address">The address of the avatar.</param>
-    /// <returns>The avatar state</returns>
-    public async Task<AvatarState> GetAvatarAsync(Address address, [Service] AvatarRepository repo) =>
-        (await repo.GetByAddressAsync(address)).Object;
-
-    /// <summary>
-    /// Get an action point by address.
-    /// </summary>
-    /// <param name="address">The address of the avatar.</param>
-    /// <returns>The action point.</returns>
-    public async Task<int> GetActionPointAsync(Address address, [Service] ActionPointRepository repo) =>
-        (await repo.GetByAddressAsync(address)).Object;
-
-    /// <summary>
-    /// Get a stake state by agent address.
-    /// </summary>
-    /// <param name="address">The address of the agent.</param>
-    /// <returns>The stake state.</returns>
-    public async Task<StakeState?> GetStakeAsync(Address address, [Service] StakeRepository repo) =>
-        (await repo.GetByAgentAddressAsync(address)).Object;
-
-    /// <summary>
     /// Get the daily reward received block index by address.
     /// </summary>
     /// <param name="address">The address of the avatar.</param>
@@ -99,19 +93,26 @@ public class Query
         => (await repo.GetByAddressAsync(address)).Object;
 
     /// <summary>
-    /// Get arena sub-fields.
+    /// Get metadata by collection name.
     /// </summary>
-    public ArenaObject GetArena() => new();
+    /// <param name="collectionName">The name of the collection.</param>
+    /// <returns>The metadata</returns>
+    public async Task<MetadataDocument> GetMetadataAsync(string collectionName, [Service] MetadataRepository repo) =>
+        await repo.GetByCollectionAsync(collectionName);
 
     /// <summary>
-    /// Get all combination slot states for a specific avatar address.
+    /// Get the pledge state for a given agent address.
     /// </summary>
-    /// <param name="avatarAddress">The address of the avatar</param>
-    /// <returns>All combination slot states for the specified avatar address.</returns>
-    public async Task<AllCombinationSlotState> GetAllCombinationSlotsAsync(
-        Address avatarAddress,
-        [Service] AllCombinationSlotStateRepository repo) =>
-        (await repo.GetByAddressAsync(avatarAddress)).Object;
+    public async Task<PledgeDocument> GetPledgeAsync(Address agentAddress, [Service] PledgeRepository repo) =>
+        await repo.GetByAddressAsync(agentAddress.GetPledgeAddress());
+
+    /// <summary>
+    /// Get the product by product ID.
+    /// </summary>
+    /// <param name="productId">The product ID</param>
+    /// <returns>The product.</returns>
+    public async Task<Product> GetProductAsync(Guid productId, [Service] ProductRepository repo) =>
+        (await repo.GetByProductIdAsync(productId)).Object;
 
     /// <summary>
     /// Get the product ids that are contained in the products state for a specific avatar address.
@@ -122,12 +123,12 @@ public class Query
         (await repo.GetByAvatarAddressAsync(avatarAddress)).Object.ProductIds;
 
     /// <summary>
-    /// Get the product by product ID.
+    /// Get a stake state by agent address.
     /// </summary>
-    /// <param name="productId">The product ID</param>
-    /// <returns>The product.</returns>
-    public async Task<Product> GetProductAsync(Guid productId, [Service] ProductRepository repo) =>
-        (await repo.GetByProductIdAsync(productId)).Object;
+    /// <param name="address">The address of the agent.</param>
+    /// <returns>The stake state.</returns>
+    public async Task<StakeState?> GetStakeAsync(Address address, [Service] StakeRepository repo) =>
+        (await repo.GetByAgentAddressAsync(address)).Object;
 
     /// <summary>
     /// Get the world boss.
@@ -157,34 +158,6 @@ public class Query
     }
 
     /// <summary>
-    /// Get the raider of world boss.
-    /// </summary>
-    public async Task<RaiderState> GetWorldBossRaiderAsync(
-        Address avatarAddress,
-        [Service] MetadataRepository metadataRepo,
-        [Service] TableSheetsRepository tableSheetsRepo,
-        [Service] WorldBossRaiderRepository worldBossRaiderRepo)
-    {
-        var collectionName = CollectionNames.GetCollectionName<WorldBossStateDocument>();
-        var metadataDocument = await metadataRepo.GetByCollectionAsync(collectionName);
-        var blockIndex = metadataDocument.LatestBlockIndex;
-        var worldBossListSheet = await tableSheetsRepo.GetSheetAsync<WorldBossListSheet>();
-        WorldBossListSheet.Row row;
-        try
-        {
-            row = worldBossListSheet.FindRowByBlockIndex(blockIndex);
-        }
-        catch (InvalidOperationException)
-        {
-            throw new GraphQLException($"Failed to find the world boss row by block index, {blockIndex}");
-        }
-
-        var raidId = row.Id;
-        var raiderAddress = Addresses.GetRaiderAddress(avatarAddress, raidId);
-        return (await worldBossRaiderRepo.GetByAddressAsync(raiderAddress)).Object;
-    }
-
-    /// <summary>
     /// Get the kill reward record of world boss.
     /// </summary>
     public async Task<WorldBossKillRewardRecord> GetWorldBossKillRewardRecordAsync(
@@ -210,5 +183,33 @@ public class Query
         var raidId = row.Id;
         var worldBossKillRewardRecordAddress = Addresses.GetWorldBossKillRewardRecordAddress(avatarAddress, raidId);
         return (await worldBossKillRewardRecordRepo.GetByAddressAsync(worldBossKillRewardRecordAddress)).Object;
+    }
+
+    /// <summary>
+    /// Get the raider of world boss.
+    /// </summary>
+    public async Task<RaiderState> GetWorldBossRaiderAsync(
+        Address avatarAddress,
+        [Service] MetadataRepository metadataRepo,
+        [Service] TableSheetsRepository tableSheetsRepo,
+        [Service] WorldBossRaiderRepository worldBossRaiderRepo)
+    {
+        var collectionName = CollectionNames.GetCollectionName<WorldBossStateDocument>();
+        var metadataDocument = await metadataRepo.GetByCollectionAsync(collectionName);
+        var blockIndex = metadataDocument.LatestBlockIndex;
+        var worldBossListSheet = await tableSheetsRepo.GetSheetAsync<WorldBossListSheet>();
+        WorldBossListSheet.Row row;
+        try
+        {
+            row = worldBossListSheet.FindRowByBlockIndex(blockIndex);
+        }
+        catch (InvalidOperationException)
+        {
+            throw new GraphQLException($"Failed to find the world boss row by block index, {blockIndex}");
+        }
+
+        var raidId = row.Id;
+        var raiderAddress = Addresses.GetRaiderAddress(avatarAddress, raidId);
+        return (await worldBossRaiderRepo.GetByAddressAsync(raiderAddress)).Object;
     }
 }

--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -122,6 +122,9 @@ public class Query
     public async Task<List<Guid>> GetProductIdsAsync(Address avatarAddress, [Service] ProductsRepository repo) =>
         (await repo.GetByAvatarAddressAsync(avatarAddress)).Object.ProductIds;
 
+    public async Task<RuneState[]> GetRunesAsync(Address avatarAddress, [Service] AllRuneRepository repo) =>
+        (await repo.GetByAddressAsync(avatarAddress)).Object.Runes.Values.ToArray();
+
     /// <summary>
     /// Get a stake state by agent address.
     /// </summary>

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -38,7 +38,7 @@ builder.Services.AddSingleton<MongoDbService>();
 builder.Services.AddSingleton<ActionPointRepository>();
 builder.Services.AddSingleton<AgentRepository>();
 builder.Services.AddSingleton<AllCombinationSlotStateRepository>();
-// builder.Services.AddSingleton<AllRuneRepository>();
+builder.Services.AddSingleton<AllRuneRepository>();
 builder.Services.AddSingleton<ArenaRepository>();
 builder.Services.AddSingleton<AvatarRepository>();
 builder.Services.AddSingleton<BalanceRepository>();

--- a/Mimir/Program.cs
+++ b/Mimir/Program.cs
@@ -34,29 +34,29 @@ builder.WebHost.UseSentry();
 builder.Services.AddAuthorization();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSingleton<MongoDbService>();
-builder.Services.AddSingleton<MetadataRepository>();
-builder.Services.AddSingleton<TableSheetsRepository>();
-builder.Services.AddSingleton<BalanceRepository>();
-builder.Services.AddSingleton<PledgeRepository>();
-builder.Services.AddSingleton<AgentRepository>();
-// AvatarState dependencies
-builder.Services.AddSingleton<AvatarRepository>();
+// NOTE: MongoDB repositories. Sort in alphabetical order.
 builder.Services.AddSingleton<ActionPointRepository>();
-builder.Services.AddSingleton<DailyRewardRepository>();
+builder.Services.AddSingleton<AgentRepository>();
 builder.Services.AddSingleton<AllCombinationSlotStateRepository>();
-// builder.Services.AddSingleton<InventoryRepository>();
 // builder.Services.AddSingleton<AllRuneRepository>();
-// builder.Services.AddSingleton<CollectionRepository>();
-builder.Services.AddSingleton<ItemSlotRepository>();
-builder.Services.AddSingleton<RuneSlotRepository>();
-// Others
 builder.Services.AddSingleton<ArenaRepository>();
-builder.Services.AddSingleton<StakeRepository>();
-builder.Services.AddSingleton<ProductsRepository>();
+builder.Services.AddSingleton<AvatarRepository>();
+builder.Services.AddSingleton<BalanceRepository>();
+// builder.Services.AddSingleton<CollectionRepository>();
+builder.Services.AddSingleton<DailyRewardRepository>();
+// builder.Services.AddSingleton<InventoryRepository>();
+builder.Services.AddSingleton<ItemSlotRepository>();
+builder.Services.AddSingleton<MetadataRepository>();
+builder.Services.AddSingleton<PledgeRepository>();
 builder.Services.AddSingleton<ProductRepository>();
-builder.Services.AddSingleton<WorldBossRepository>();
-builder.Services.AddSingleton<WorldBossRaiderRepository>();
+builder.Services.AddSingleton<ProductsRepository>();
+builder.Services.AddSingleton<RuneSlotRepository>();
+builder.Services.AddSingleton<StakeRepository>();
+builder.Services.AddSingleton<TableSheetsRepository>();
 builder.Services.AddSingleton<WorldBossKillRewardRecordRepository>();
+builder.Services.AddSingleton<WorldBossRaiderRepository>();
+builder.Services.AddSingleton<WorldBossRepository>();
+// ~MongoDB repositories.
 builder.Services.AddCors();
 builder.Services.AddHttpClient();
 builder.Services


### PR DESCRIPTION
- Sort some methods and lines in alphabetical order.
- Fix "allCombinationSlotStates" to "combinationSlotStates"
- Code clean up of `CollectionNames`
- Register `AllRuneDocument` type to `CollectionNames`
- Add `init` keyword to `AllRuneState.Runes` property
- Fix `AllRuneRepository` and register to program services
- Add "runes" graphQL query

# Examples

```graphql
query {
  runes(avatarAddress: "Ae441376eb509Aad4eE57cefca1fB79FB5e34251") {
    level
    runeId
  }
}
```
```json
{
  "data": {
    "runes": [
      {
        "level": 1,
        "runeId": 10001
      },
      {
        "level": 26,
        "runeId": 30001
      }
    ]
  }
}
```