### PR TITLE
Force lowercase database name

### DIFF
--- a/Mimir.Worker/Services/MongoDbService.cs
+++ b/Mimir.Worker/Services/MongoDbService.cs
@@ -53,7 +53,7 @@ public class MongoDbService
         }
 
         _client = new MongoClient(settings);
-        _database = _client.GetDatabase(planetType.ToString());
+        _database = _client.GetDatabase(planetType.ToString().ToLowerInvariant());
         _gridFs = new GridFSBucket(_database);
         _stateCollectionMappings = InitStateCollections();
         _metadataCollection = _database.GetCollection<MetadataDocument>("metadata");


### PR DESCRIPTION
It resolves #408.

Since #403, `PlanetType` becomes enum type. And its `ToString` behavior has changed so such situation was occurred. This pull request forces using lowercase database name.

# Note

Previous implementation:

https://github.com/planetarium/mimir/blob/3b64444708acf2eb6a2c0caca8d322f329b30d90/Mimir.Worker/Constants/PlanetType.cs#L27-L29

Current implementation:

See https://learn.microsoft.com/en-us/dotnet/api/system.enum.tostring?view=net-8.0