### PR TITLE
feat: introduce `Lock` and `OrderLock` to `Lib9c.Models` project

### DIFF
--- a/Lib9c.Models/Items/Lock.cs
+++ b/Lib9c.Models/Items/Lock.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+using Bencodex;
+using Bencodex.Types;
+using Lib9c.Models.Exceptions;
+using MongoDB.Bson.Serialization.Attributes;
+using Nekoyume.Model.Item;
+using Nekoyume.Model.State;
+using ValueKind = Bencodex.Types.ValueKind;
+
+namespace Lib9c.Models.Items;
+
+/// <summary>
+/// <see cref="Nekoyume.Model.Item.ILock"/>
+/// </summary>
+public record Lock : IBencodable, ILock
+{
+    public LockType Type { get; init; }
+
+    [BsonIgnore, GraphQLIgnore, JsonIgnore]
+    public virtual IValue Bencoded => new List(Type.Serialize());
+
+    public Lock()
+    {
+    }
+
+    public Lock(IValue bencoded)
+    {
+        if (bencoded is not List l)
+        {
+            throw new UnsupportedArgumentTypeException<ValueKind>(
+                nameof(bencoded),
+                new[] { ValueKind.List },
+                bencoded.Kind);
+        }
+
+        Type = l[0].ToEnum<LockType>();
+    }
+
+    public IValue Serialize() => Bencoded;
+}

--- a/Lib9c.Models/Items/OrderLock.cs
+++ b/Lib9c.Models/Items/OrderLock.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
 using Bencodex.Types;
 using Lib9c.Models.Exceptions;
+using MongoDB.Bson.Serialization.Attributes;
+using Nekoyume.Model.Item;
 using Nekoyume.Model.State;
 using ValueKind = Bencodex.Types.ValueKind;
 
@@ -12,15 +15,16 @@ public record OrderLock : Lock
 {
     public Guid OrderId { get; init; }
 
+    [BsonIgnore, GraphQLIgnore, JsonIgnore]
     public override IValue Bencoded => new List(
-        base.Bencoded,
+        Type.Serialize(),
         OrderId.Serialize());
 
     public OrderLock()
     {
     }
 
-    public OrderLock(IValue bencoded) : base(bencoded)
+    public OrderLock(IValue bencoded)
     {
         if (bencoded is not List l)
         {
@@ -29,7 +33,8 @@ public record OrderLock : Lock
                 new[] { ValueKind.List },
                 bencoded.Kind);
         }
-        
+
+        Type = l[0].ToEnum<LockType>();
         OrderId = l[1].ToGuid();
     }
 }

--- a/Lib9c.Models/Items/OrderLock.cs
+++ b/Lib9c.Models/Items/OrderLock.cs
@@ -1,0 +1,35 @@
+using Bencodex.Types;
+using Lib9c.Models.Exceptions;
+using Nekoyume.Model.State;
+using ValueKind = Bencodex.Types.ValueKind;
+
+namespace Lib9c.Models.Items;
+
+/// <summary>
+/// <see cref="Nekoyume.Model.Item.OrderLock"/>
+/// </summary>
+public record OrderLock : Lock
+{
+    public Guid OrderId { get; init; }
+
+    public override IValue Bencoded => new List(
+        base.Bencoded,
+        OrderId.Serialize());
+
+    public OrderLock()
+    {
+    }
+
+    public OrderLock(IValue bencoded) : base(bencoded)
+    {
+        if (bencoded is not List l)
+        {
+            throw new UnsupportedArgumentTypeException<ValueKind>(
+                nameof(bencoded),
+                new[] { ValueKind.List },
+                bencoded.Kind);
+        }
+        
+        OrderId = l[1].ToGuid();
+    }
+}


### PR DESCRIPTION
The `Lib9c.Models.Items.Lock` type which is introducing newly in this pull request reproduce the `Nekoyume.Model.Item.ILock` interface. And It's experimental approach for me.
Actually, there are no usages this type but it can be possible to hinting in the future.