### PR TITLE
[FIX]:Fixed the typo in comment

### DIFF
--- a/Mimir/GraphQL/Queries/Query.cs
+++ b/Mimir/GraphQL/Queries/Query.cs
@@ -120,7 +120,7 @@ public class Query
     /// <summary>
     /// Get an pet state by avatar address.
     /// </summary>
-    /// <param name="avatarAddress">The address of the agent.</param>
+    /// <param name="avatarAddress">The address of the avatar.</param>
     /// <returns>The agent state</returns>
     public async Task<PetState> GetPetAsync(Address avatarAddress, [Service] PetRepository repo) =>
         (await repo.GetByAvatarAddressAsync(avatarAddress)).Object;


### PR DESCRIPTION
Closes #413 

Corrected the typo in the param name comment of Query.GetPetAsync(avatarAddress, repo) method.