### PR TITLE
Recover devcontainer

### DIFF
--- a/.devcontainer/bin/postAttachCommand.sh
+++ b/.devcontainer/bin/postAttachCommand.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dotnet restore

--- a/.devcontainer/bin/postCreateCommand.sh
+++ b/.devcontainer/bin/postCreateCommand.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ev
+
+sudo apt update -qq
+sudo apt install -qq -y vim
+
+git config core.editor "vim"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,37 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
-	"name": "C# (.NET)",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm",
+	"name": "Mimir & Mimir.Worker",
+    "dockerComposeFile": [
+		"../docker-compose.yml",
+		"docker-compose.yml"
+	],
+    "service": "devcontainer",
+    "workspaceFolder": "/workspace",
 	"features": {
-		"ghcr.io/devcontainers/features/dotnet:2": {},
-		"ghcr.io/devcontainers/features/github-cli:1": {},
-		"ghcr.io/devcontainers-contrib/features/mongodb-atlas-cli-homebrew:1": {},
-		"ghcr.io/devcontainers-contrib/features/mongosh-homebrew:1": {}
+		"ghcr.io/devcontainers/features/dotnet:2": {
+			"version": "latest"
+		},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [5195, 7272],
+	"forwardPorts": [7272, 27017],
 	"portsAttributes": {
         "7272": {
+			"label": "MongoDB",
             "protocol": "https"
-        }
+        },
+		"27017": {
+			"label": "MongoDB"
+		}
 	},
-
-	// Use 'postCreateCommand' to run commands after the container is created.
-    "postAttachCommand": "./.devcontainer/scripts/postCreateCommand.sh"
-
-	// Configure tool-specific properties.
-	// "customizations": {},
-
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    "postCreateCommand": "./.devcontainer/bin/postCreateCommand.sh",
+    "postAttachCommand": "./.devcontainer/bin/postAttachCommand.sh",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-dotnettools.vscode-dotnet-runtime",
+				"ms-dotnettools.csharp",
+				"ms-dotnettools.csdevkit",
+				"mongodb.mongodb-vscode"
+			]
+		}
+	}
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  devcontainer:
+    image: mcr.microsoft.com/devcontainers/dotnet:1-8.0-bookworm
+    volumes:
+      - .:/workspace
+    network_mode: service:mongo
+    command: sleep infinity

--- a/.devcontainer/scripts/postCreateCommand.sh
+++ b/.devcontainer/scripts/postCreateCommand.sh
@@ -1,4 +1,0 @@
-dotnet restore
-dotnet tool restore
-dotnet graphql generate Mimir
-dotnet graphql generate Mimir.Worker

--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,5 @@ obj/
 Generated
 
 appsettings.local.json
+
+!.devcontainer/bin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  mongo:
+    image: mongo:latest
+    restart: unless-stopped
+    ports:
+      - "27017:27017"


### PR DESCRIPTION
## Overview

 - It introduces `/docker-compose.yml` docker-compose configuration. Contributor can start mongodb with `docker-compose up -d`.
 - It reorganize devcontainer. It automatically start mongo service as container, contributors can use it in development.