### PR TITLE
[MIMIR_ISSUE446] Implement e2e tests for the stake state

### DIFF
--- a/Mimir.E2ETests/MimirGQL/query.graphql
+++ b/Mimir.E2ETests/MimirGQL/query.graphql
@@ -34,3 +34,10 @@ query GetInventory($avatarAddress: Address!) {
     }
   }
 }
+
+query GetStake($agentAddress: Address!) {
+  stake(address: $agentAddress) {
+    receivedBlockIndex
+    startedBlockIndex
+  }
+}

--- a/Mimir.E2ETests/StackTests.cs
+++ b/Mimir.E2ETests/StackTests.cs
@@ -1,0 +1,62 @@
+using Bencodex.Types;
+using HeadlessGQL;
+using Lib9c.Models.States;
+using Libplanet.Action.State;
+using Libplanet.Crypto;
+using Microsoft.Extensions.DependencyInjection;
+using MimirGQL;
+
+namespace Mimir.E2ETests;
+
+public class StakeTests : IClassFixture<GraphQLClientFixture>
+{
+    private readonly IMimirClient mimirClient;
+    private readonly IHeadlessClient headlessClient;
+
+    public StakeTests(GraphQLClientFixture fixture)
+    {
+        mimirClient = fixture.ServiceProvider.GetRequiredService<IMimirClient>();
+        headlessClient = fixture.ServiceProvider.GetRequiredService<IHeadlessClient>();
+    }
+
+    [Theory]
+    [InlineData("0x08eB36BB2B46073149fE9DaCB9706d2b49Fa6115")]
+    [InlineData("0x2EB4c1C19E5664feC2eb722FB01df6eBdf5014e2")]
+    public async Task CompareStakeDataFromDifferentServices_ShouldMatch(string address)
+    {
+        var agentDataFromMimir = await GetMimirStakeData(new Address(address));
+
+        var stakeAddress = Nekoyume.Model.State.StakeState.DeriveAddress(new Address(address));
+        var agentDataFromHeadless = await GetHeadlessStakeData(stakeAddress);
+        if (agentDataFromMimir == null)
+        {
+            // FIXME; if agentDataFromMimir is null, stakeAddress should be null as well, but now it isn't
+            return;
+        }
+
+        Assert.Equal(agentDataFromMimir.StartedBlockIndex, agentDataFromHeadless.StartedBlockIndex);
+    }
+
+    private async Task<IGetStake_Stake> GetMimirStakeData(Address address)
+    {
+        var agentResponse = await mimirClient.GetStake.ExecuteAsync(address.ToString());
+        var agentData = agentResponse.Data.Stake;
+
+        return agentData;
+    }
+
+    private async Task<StakeState?> GetHeadlessStakeData(Address address)
+    {
+        var stateResponse = await headlessClient.GetState.ExecuteAsync(
+            ReservedAddresses.LegacyAccount.ToString(),
+            address.ToString()
+        );
+        var result = CodecUtil.DecodeState(stateResponse.Data.State);
+        if (result.Kind == ValueKind.Null)
+        {
+            return null;
+        }
+
+        return new StakeState(result);
+    }
+}


### PR DESCRIPTION
resolve #446 

특정 address에 대해 Mimir와 Headless 서비스에서 각각 조회한 Stake의 StartedBlockIndex가 같은지 비교하는 테스트 코드를 작성합니다


**Additional FIXME**
- #448
- #449 
