### PR TITLE
fix: handling serialized enum date in MongoDB effectively and more

### DIFF
--- a/Lib9c.Models/Market/FavProduct.cs
+++ b/Lib9c.Models/Market/FavProduct.cs
@@ -15,11 +15,15 @@ namespace Lib9c.Models.Market;
 [BsonIgnoreExtraElements]
 public record FavProduct : Product, IBencodable
 {
-    public FungibleAssetValue Asset { get; }
+    public FungibleAssetValue Asset { get; init; }
 
     [BsonIgnore, GraphQLIgnore, JsonIgnore]
     public new IValue Bencoded => ((List)base.Bencoded)
         .Add(Asset.Serialize());
+
+    public FavProduct()
+    {
+    }
 
     public FavProduct(IValue bencoded) : base(bencoded)
     {

--- a/Lib9c.Models/Market/ItemProduct.cs
+++ b/Lib9c.Models/Market/ItemProduct.cs
@@ -24,6 +24,10 @@ public record ItemProduct : Product, IBencodable
         .Add(TradableItem.Bencoded)
         .Add(ItemCount.Serialize());
 
+    public ItemProduct()
+    {
+    }
+
     public ItemProduct(IValue bencoded) : base(bencoded)
     {
         if (bencoded is not List l)

--- a/Lib9c.Models/Market/Product.cs
+++ b/Lib9c.Models/Market/Product.cs
@@ -32,6 +32,10 @@ public record Product : IBencodable
         .Add(SellerAgentAddress.Serialize())
         .Add(SellerAvatarAddress.Serialize());
 
+    public Product()
+    {
+    }
+
     public Product(IValue bencoded)
     {
         if (bencoded is not List l)

--- a/Mimir.MongoDB/Bson/Extensions/BsonValueExtensions.cs
+++ b/Mimir.MongoDB/Bson/Extensions/BsonValueExtensions.cs
@@ -14,4 +14,15 @@ public static class BsonValueExtensions
                 [BsonType.Int32, BsonType.Int64],
                 value.BsonType)
         };
+
+    public static T ToEnum<T>(this BsonValue value) where T : struct =>
+        value.BsonType switch
+        {
+            BsonType.Int32 => (T)Enum.ToObject(typeof(T), value.AsInt32),
+            BsonType.Int64 => (T)Enum.ToObject(typeof(T), value.AsInt64),
+            BsonType.String => Enum.Parse<T>(value.AsString),
+            _ => throw new UnexpectedTypeOfBsonValueException(
+                [BsonType.Int32, BsonType.Int64, BsonType.String],
+                value.BsonType)
+        };
 }

--- a/Mimir.MongoDB/Bson/Serialization/SerializationRegistry.cs
+++ b/Mimir.MongoDB/Bson/Serialization/SerializationRegistry.cs
@@ -1,6 +1,7 @@
 using System.Numerics;
 using Lib9c.Models.AttachmentActionResults;
 using Lib9c.Models.Items;
+using Lib9c.Models.Market;
 using Lib9c.Models.Skills;
 using Lib9c.Models.States;
 using Lib9c.Models.Stats;
@@ -8,6 +9,7 @@ using Libplanet.Crypto;
 using Libplanet.Types.Assets;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.AttachmentActionResults;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Items;
+using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Market;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Sheets;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Skills;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.States;
@@ -84,6 +86,11 @@ public static class SerializationRegistry
             typeof(Dictionary<Material, int>),
             new DictionaryInterfaceImplementerSerializer<Dictionary<Material, int>>()
                 .WithKeySerializer(MaterialSerializer.Instance));
+
+        // Lib9c.Models.Market
+        BsonSerializer.RegisterSerializer(typeof(Product), ProductSerializer.Instance);
+        BsonSerializer.RegisterSerializer(typeof(FavProduct), FavProductSerializer.Instance);
+        BsonSerializer.RegisterSerializer(typeof(ItemProduct), ItemProductSerializer.Instance);
 
         // Lib9c.Models.Skills
         BsonSerializer.RegisterSerializer(typeof(Skill), SkillSerializer.Instance);

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/AttachmentActionResults/ItemEnhancement11ResultSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/AttachmentActionResults/ItemEnhancement11ResultSerializer.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Lib9c.Models.AttachmentActionResults;
+using Mimir.MongoDB.Bson.Extensions;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Items;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
 using MongoDB.Bson;
@@ -30,8 +31,7 @@ public class ItemEnhancement11ResultSerializer : ClassSerializerBase<ItemEnhance
         MaterialItemIdList = doc["MaterialItemIdList"].AsBsonArray.Select(id => Guid.Parse(id.AsString)),
         Gold = BigInteger.Parse(doc["Gold"].AsString),
         ActionPoint = doc["ActionPoint"].AsInt32,
-        EnhancementResult =
-            Enum.Parse<Nekoyume.Action.ItemEnhancement9.EnhancementResult>(doc["EnhancementResult"].AsString),
+        EnhancementResult = doc["EnhancementResult"].ToEnum<Nekoyume.Action.ItemEnhancement9.EnhancementResult>(),
         PreItemUsable = doc.TryGetValue("PreItemUsable", out var preItemUsableBsonValue)
             ? ItemUsableSerializer.Deserialize(preItemUsableBsonValue.AsBsonDocument)
             : null,

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/AttachmentActionResults/ItemEnhancement12ResultSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/AttachmentActionResults/ItemEnhancement12ResultSerializer.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Lib9c.Models.AttachmentActionResults;
+using Mimir.MongoDB.Bson.Extensions;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Items;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
 using MongoDB.Bson;
@@ -29,8 +30,7 @@ public class ItemEnhancement12ResultSerializer : ClassSerializerBase<ItemEnhance
         MaterialItemIdList = doc["MaterialItemIdList"].AsBsonArray.Select(id => Guid.Parse(id.AsString)),
         Gold = BigInteger.Parse(doc["Gold"].AsString),
         ActionPoint = doc["ActionPoint"].AsInt32,
-        EnhancementResult =
-            Enum.Parse<Nekoyume.Action.ItemEnhancement9.EnhancementResult>(doc["EnhancementResult"].AsString),
+        EnhancementResult = doc["EnhancementResult"].ToEnum<Nekoyume.Action.ItemEnhancement9.EnhancementResult>(),
         PreItemUsable = doc.TryGetValue("PreItemUsable", out var preItemUsableBsonValue)
             ? ItemUsableSerializer.Deserialize(preItemUsableBsonValue.AsBsonDocument)
             : null,

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/AttachmentActionResults/ItemEnhancement13ResultSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/AttachmentActionResults/ItemEnhancement13ResultSerializer.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Lib9c.Models.AttachmentActionResults;
+using Mimir.MongoDB.Bson.Extensions;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Items;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
 using MongoDB.Bson;
@@ -29,8 +30,7 @@ public class ItemEnhancement13ResultSerializer : ClassSerializerBase<ItemEnhance
         MaterialItemIdList = doc["MaterialItemIdList"].AsBsonArray.Select(id => Guid.Parse(id.AsString)),
         Gold = BigInteger.Parse(doc["Gold"].AsString),
         ActionPoint = doc["ActionPoint"].AsInt32,
-        EnhancementResult =
-            Enum.Parse<Nekoyume.Action.ItemEnhancement9.EnhancementResult>(doc["EnhancementResult"].AsString),
+        EnhancementResult = doc["EnhancementResult"].ToEnum<Nekoyume.Action.ItemEnhancement9.EnhancementResult>(),
         PreItemUsable = doc.TryGetValue("PreItemUsable", out var preItemUsableBsonValue)
             ? ItemUsableSerializer.Deserialize(preItemUsableBsonValue.AsBsonDocument)
             : null,

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/AttachmentActionResults/ItemEnhancement9ResultSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/AttachmentActionResults/ItemEnhancement9ResultSerializer.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Lib9c.Models.AttachmentActionResults;
+using Mimir.MongoDB.Bson.Extensions;
 using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Items;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
@@ -29,8 +30,7 @@ public class ItemEnhancement9ResultSerializer : ClassSerializerBase<ItemEnhancem
         MaterialItemIdList = doc["MaterialItemIdList"].AsBsonArray.Select(id => Guid.Parse(id.AsString)),
         Gold = BigInteger.Parse(doc["Gold"].AsString),
         ActionPoint = doc["ActionPoint"].AsInt32,
-        EnhancementResult =
-            Enum.Parse<Nekoyume.Action.ItemEnhancement9.EnhancementResult>(doc["EnhancementResult"].AsString),
+        EnhancementResult = doc["EnhancementResult"].ToEnum<Nekoyume.Action.ItemEnhancement9.EnhancementResult>(),
         PreItemUsable = doc.TryGetValue("PreItemUsable", out var preItemUsableBsonValue)
             ? ItemUsableSerializer.Deserialize(preItemUsableBsonValue.AsBsonDocument)
             : null,

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/ConsumableSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/ConsumableSerializer.cs
@@ -16,9 +16,9 @@ public class ConsumableSerializer : ClassSerializerBase<Consumable>
     {
         Id = doc["Id"].AsInt32,
         Grade = doc["Grade"].AsInt32,
-        ItemType = Enum.Parse<Nekoyume.Model.Item.ItemType>(doc["ItemType"].AsString),
-        ItemSubType = Enum.Parse<Nekoyume.Model.Item.ItemSubType>(doc["ItemSubType"].AsString),
-        ElementalType = Enum.Parse<Nekoyume.Model.Elemental.ElementalType>(doc["ElementalType"].AsString),
+        ItemType = doc["ItemType"].ToEnum<Nekoyume.Model.Item.ItemType>(),
+        ItemSubType = doc["ItemSubType"].ToEnum<Nekoyume.Model.Item.ItemSubType>(),
+        ElementalType = doc["ElementalType"].ToEnum<Nekoyume.Model.Elemental.ElementalType>(),
         ItemId = Guid.Parse(doc["ItemId"].AsString),
         StatsMap = StatMapSerializer.Deserialize(doc["StatsMap"].AsBsonDocument),
         Skills = doc["Skills"].AsBsonArray

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/CostumeSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/CostumeSerializer.cs
@@ -14,9 +14,9 @@ public class CostumeSerializer : ClassSerializerBase<Costume>
     {
         Id = doc["Id"].AsInt32,
         Grade = doc["Grade"].AsInt32,
-        ItemType = Enum.Parse<Nekoyume.Model.Item.ItemType>(doc["ItemType"].AsString),
-        ItemSubType = Enum.Parse<Nekoyume.Model.Item.ItemSubType>(doc["ItemSubType"].AsString),
-        ElementalType = Enum.Parse<Nekoyume.Model.Elemental.ElementalType>(doc["ElementalType"].AsString),
+        ItemType = doc["ItemType"].ToEnum<Nekoyume.Model.Item.ItemType>(),
+        ItemSubType = doc["ItemSubType"].ToEnum<Nekoyume.Model.Item.ItemSubType>(),
+        ElementalType = doc["ElementalType"].ToEnum<Nekoyume.Model.Elemental.ElementalType>(),
         Equipped = doc["Equipped"].AsBoolean,
         SpineResourcePath = doc["SpineResourcePath"].AsString,
         ItemId = Guid.Parse(doc["ItemId"].AsString),

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/EquipmentSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/EquipmentSerializer.cs
@@ -24,8 +24,8 @@ public class EquipmentSerializer : ClassSerializerBase<Equipment>
             throw new BsonSerializationException("Missing itemSubTypeValue in document.");
         }
 
-        var itemType = Enum.Parse<Nekoyume.Model.Item.ItemType>(itemTypeBsonValue.AsString);
-        var itemSubType = Enum.Parse<Nekoyume.Model.Item.ItemSubType>(itemSubTypeBsonValue.AsString);
+        var itemType = itemTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemType>();
+        var itemSubType = itemSubTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemSubType>();
         return itemType switch
         {
             Nekoyume.Model.Item.ItemType.Equipment => itemSubType switch
@@ -49,9 +49,9 @@ public class EquipmentSerializer : ClassSerializerBase<Equipment>
     {
         Id = doc["Id"].AsInt32,
         Grade = doc["Grade"].AsInt32,
-        ItemType = Enum.Parse<Nekoyume.Model.Item.ItemType>(doc["ItemType"].AsString),
-        ItemSubType = Enum.Parse<Nekoyume.Model.Item.ItemSubType>(doc["ItemSubType"].AsString),
-        ElementalType = Enum.Parse<Nekoyume.Model.Elemental.ElementalType>(doc["ElementalType"].AsString),
+        ItemType = doc["ItemType"].ToEnum<Nekoyume.Model.Item.ItemType>(),
+        ItemSubType = doc["ItemSubType"].ToEnum<Nekoyume.Model.Item.ItemSubType>(),
+        ElementalType = doc["ElementalType"].ToEnum<Nekoyume.Model.Elemental.ElementalType>(),
         ItemId = Guid.Parse(doc["ItemId"].AsString),
         StatsMap = StatMapSerializer.Deserialize(doc["StatsMap"].AsBsonDocument),
         Skills = doc["Skills"].AsBsonArray

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/ItemBaseSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/ItemBaseSerializer.cs
@@ -1,4 +1,5 @@
 using Lib9c.Models.Items;
+using Mimir.MongoDB.Bson.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
@@ -21,8 +22,8 @@ public class ItemBaseSerializer : ClassSerializerBase<ItemBase>
             throw new BsonSerializationException("Missing itemSubTypeValue in document.");
         }
 
-        var itemType = Enum.Parse<Nekoyume.Model.Item.ItemType>(itemTypeBsonValue.AsString);
-        var itemSubType = Enum.Parse<Nekoyume.Model.Item.ItemSubType>(itemSubTypeBsonValue.AsString);
+        var itemType = itemTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemType>();
+        var itemSubType = itemSubTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemSubType>();
         return itemType switch
         {
             Nekoyume.Model.Item.ItemType.Consumable or

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/ItemUsableSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/ItemUsableSerializer.cs
@@ -1,4 +1,5 @@
 using Lib9c.Models.Items;
+using Mimir.MongoDB.Bson.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
@@ -21,8 +22,8 @@ public class ItemUsableSerializer : ClassSerializerBase<ItemUsable>
             throw new BsonSerializationException("Missing itemSubTypeValue in document.");
         }
 
-        var itemType = Enum.Parse<Nekoyume.Model.Item.ItemType>(itemTypeBsonValue.AsString);
-        var itemSubType = Enum.Parse<Nekoyume.Model.Item.ItemSubType>(itemSubTypeBsonValue.AsString);
+        var itemType = itemTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemType>();
+        var itemSubType = itemSubTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemSubType>();
         return itemType switch
         {
             Nekoyume.Model.Item.ItemType.Consumable => ConsumableSerializer.Deserialize(doc),

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/MaterialSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/MaterialSerializer.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Lib9c.Models.Items;
 using Libplanet.Common;
+using Mimir.MongoDB.Bson.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
@@ -24,8 +25,8 @@ public class MaterialSerializer : ClassSerializerBase<Material>
             throw new BsonSerializationException("Missing itemSubTypeValue in document.");
         }
 
-        var itemType = Enum.Parse<Nekoyume.Model.Item.ItemType>(itemTypeBsonValue.AsString);
-        var itemSubType = Enum.Parse<Nekoyume.Model.Item.ItemSubType>(itemSubTypeBsonValue.AsString);
+        var itemType = itemTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemType>();
+        var itemSubType = itemSubTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemSubType>();
         if (itemType != Nekoyume.Model.Item.ItemType.Material)
         {
             throw new BsonSerializationException($"Unsupported ItemType: {itemType} or ItemSubType: {itemSubType}");
@@ -42,7 +43,7 @@ public class MaterialSerializer : ClassSerializerBase<Material>
             Grade = doc["Grade"].AsInt32,
             ItemType = itemType,
             ItemSubType = itemSubType,
-            ElementalType = Enum.Parse<Nekoyume.Model.Elemental.ElementalType>(doc["ElementalType"].AsString),
+            ElementalType = doc["ElementalType"].ToEnum<Nekoyume.Model.Elemental.ElementalType>(),
             ItemId = HashDigest<SHA256>.FromString(doc["ItemId"].AsString),
         };
     }

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/TradableMaterialSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Items/TradableMaterialSerializer.cs
@@ -1,6 +1,7 @@
 using System.Security.Cryptography;
 using Lib9c.Models.Items;
 using Libplanet.Common;
+using Mimir.MongoDB.Bson.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
@@ -24,8 +25,8 @@ public class TradableMaterialSerializer : ClassSerializerBase<TradableMaterial>
             throw new BsonSerializationException("Missing itemSubTypeValue in document.");
         }
 
-        var itemType = Enum.Parse<Nekoyume.Model.Item.ItemType>(itemTypeBsonValue.AsString);
-        var itemSubType = Enum.Parse<Nekoyume.Model.Item.ItemSubType>(itemSubTypeBsonValue.AsString);
+        var itemType = itemTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemType>();
+        var itemSubType = itemSubTypeBsonValue.ToEnum<Nekoyume.Model.Item.ItemSubType>();
         if (itemType != Nekoyume.Model.Item.ItemType.Material)
         {
             throw new BsonSerializationException($"Unsupported ItemType: {itemType} or ItemSubType: {itemSubType}");
@@ -37,7 +38,7 @@ public class TradableMaterialSerializer : ClassSerializerBase<TradableMaterial>
             Grade = doc["Grade"].AsInt32,
             ItemType = itemType,
             ItemSubType = itemSubType,
-            ElementalType = Enum.Parse<Nekoyume.Model.Elemental.ElementalType>(doc["ElementalType"].AsString),
+            ElementalType = doc["ElementalType"].ToEnum<Nekoyume.Model.Elemental.ElementalType>(),
             ItemId = HashDigest<SHA256>.FromString(doc["ItemId"].AsString),
             RequiredBlockIndex = doc["RequiredBlockIndex"].AsInt64,
         };

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Market/FavProductSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Market/FavProductSerializer.cs
@@ -1,0 +1,37 @@
+using Lib9c.Models.Market;
+using Libplanet.Crypto;
+using Mimir.MongoDB.Bson.Extensions;
+using Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Market;
+
+public class FavProductSerializer : ClassSerializerBase<FavProduct>
+{
+    public static readonly ProductSerializer Instance = new();
+
+    public static FavProduct Deserialize(BsonDocument doc) => new()
+    {
+        ProductId = Guid.Parse(doc["ProductId"].AsString),
+        ProductType = doc["ProductType"].ToEnum<Nekoyume.Model.Market.ProductType>(),
+        Price = FungibleAssetValueSerializer.Deserialize(doc["Price"].AsBsonDocument),
+        RegisteredBlockIndex = doc["RegisteredBlockIndex"].ToLong(),
+        SellerAvatarAddress = new Address(doc["SellerAvatarAddress"].AsString),
+        SellerAgentAddress = new Address(doc["SellerAgentAddress"].AsString),
+        Asset = FungibleAssetValueSerializer.Deserialize(doc["Asset"].AsBsonDocument),
+    };
+
+    public override FavProduct Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        var doc = BsonDocumentSerializer.Instance.Deserialize(context, args);
+        return Deserialize(doc);
+    }
+
+    // DO NOT OVERRIDE Serialize METHOD: Currently objects will be serialized to Json first.
+    // public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, ItemBase value)
+    // {
+    //     base.Serialize(context, args, value);
+    // }
+}

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Market/ItemProductSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Market/ItemProductSerializer.cs
@@ -1,0 +1,39 @@
+using Lib9c.Models.Market;
+using Libplanet.Crypto;
+using Mimir.MongoDB.Bson.Extensions;
+using Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Items;
+using Mimir.MongoDB.Bson.Serialization.Serializers.Libplanet;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Market;
+
+public class ItemProductSerializer : ClassSerializerBase<ItemProduct>
+{
+    public static readonly ProductSerializer Instance = new();
+
+    public static ItemProduct Deserialize(BsonDocument doc) => new()
+    {
+        ProductId = Guid.Parse(doc["ProductId"].AsString),
+        ProductType = doc["ProductType"].ToEnum<Nekoyume.Model.Market.ProductType>(),
+        Price = FungibleAssetValueSerializer.Deserialize(doc["Price"].AsBsonDocument),
+        RegisteredBlockIndex = doc["RegisteredBlockIndex"].ToLong(),
+        SellerAvatarAddress = new Address(doc["SellerAvatarAddress"].AsString),
+        SellerAgentAddress = new Address(doc["SellerAgentAddress"].AsString),
+        TradableItem = ItemBaseSerializer.Deserialize(doc["TradableItem"].AsBsonDocument),
+        ItemCount = doc["ItemCount"].AsInt32,
+    };
+
+    public override ItemProduct Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        var doc = BsonDocumentSerializer.Instance.Deserialize(context, args);
+        return Deserialize(doc);
+    }
+
+    // DO NOT OVERRIDE Serialize METHOD: Currently objects will be serialized to Json first.
+    // public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, ItemBase value)
+    // {
+    //     base.Serialize(context, args, value);
+    // }
+}

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Market/ProductSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Market/ProductSerializer.cs
@@ -1,0 +1,41 @@
+using Lib9c.Models.Market;
+using Mimir.MongoDB.Bson.Extensions;
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace Mimir.MongoDB.Bson.Serialization.Serializers.Lib9c.Market;
+
+public class ProductSerializer : ClassSerializerBase<Product>
+{
+    public static readonly ProductSerializer Instance = new();
+
+    public static Product Deserialize(BsonDocument doc)
+    {
+        if (!doc.TryGetValue("ProductType", out var productTypeValue))
+        {
+            throw new BsonSerializationException("Missing ItemType in document.");
+        }
+
+        var productType = productTypeValue.ToEnum<Nekoyume.Model.Market.ProductType>();
+        return productType switch
+        {
+            Nekoyume.Model.Market.ProductType.Fungible or
+                Nekoyume.Model.Market.ProductType.NonFungible => ItemProductSerializer.Deserialize(doc),
+            Nekoyume.Model.Market.ProductType.FungibleAssetValue => FavProductSerializer.Deserialize(doc),
+            _ => throw new BsonSerializationException($"Unsupported ProductType: {productType}"),
+        };
+    }
+
+    public override Product Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+    {
+        var doc = BsonDocumentSerializer.Instance.Deserialize(context, args);
+        return Deserialize(doc);
+    }
+
+    // DO NOT OVERRIDE Serialize METHOD: Currently objects will be serialized to Json first.
+    // public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, ItemBase value)
+    // {
+    //     base.Serialize(context, args, value);
+    // }
+}

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Sheets/SkillSheetRowSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Sheets/SkillSheetRowSerializer.cs
@@ -1,3 +1,4 @@
+using Mimir.MongoDB.Bson.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
@@ -14,10 +15,10 @@ public class SkillSheetRowSerializer : ClassSerializerBase<SkillSheet.Row>
         var fields = new[]
         {
             doc["Id"].AsInt32.ToString(),
-            doc["ElementalType"].AsString,
-            doc["SkillType"].AsString,
-            doc["SkillCategory"].AsString,
-            doc["SkillTargetType"].AsString,
+            doc["ElementalType"].ToEnum<Nekoyume.Model.Elemental.ElementalType>().ToString(),
+            doc["SkillType"].ToEnum<Nekoyume.Model.Skill.SkillType>().ToString(),
+            doc["SkillCategory"].ToEnum<Nekoyume.Model.Skill.SkillCategory>().ToString(),
+            doc["SkillTargetType"].ToEnum<Nekoyume.Model.Skill.SkillTargetType>().ToString(),
             doc["HitCount"].AsInt32.ToString(),
             doc["Cooldown"].AsInt32.ToString(),
             doc["Combo"].AsBoolean.ToString(),

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Skills/SkillSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Skills/SkillSerializer.cs
@@ -17,7 +17,7 @@ public class SkillSerializer : ClassSerializerBase<Skill>
         Power = doc["Power"].ToLong(),
         Chance = doc["Chance"].AsInt32,
         StatPowerRatio = doc["StatPowerRatio"].AsInt32,
-        ReferencedStatType = Enum.Parse<Nekoyume.Model.Stat.StatType>(doc["ReferencedStatType"].AsString),
+        ReferencedStatType = doc["ReferencedStatType"].ToEnum<Nekoyume.Model.Stat.StatType>(),
     };
 
     public override Skill Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)

--- a/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Stats/DecimalStatSerializer.cs
+++ b/Mimir.MongoDB/Bson/Serialization/Serializers/Lib9c/Stats/DecimalStatSerializer.cs
@@ -1,4 +1,5 @@
 using Lib9c.Models.Stats;
+using Mimir.MongoDB.Bson.Extensions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Bson.Serialization.Serializers;
@@ -11,7 +12,7 @@ public class DecimalStatSerializer : ClassSerializerBase<DecimalStat>
 
     public static DecimalStat Deserialize(BsonDocument doc) => new()
     {
-        StatType = Enum.Parse<Nekoyume.Model.Stat.StatType>(doc["StatType"].AsString),
+        StatType = doc["StatType"].ToEnum<Nekoyume.Model.Stat.StatType>(),
         BaseValue = (decimal)doc["BaseValue"].AsDouble,
         AdditionalValue = (decimal)doc["AdditionalValue"].AsDouble,
     };

--- a/Mimir.MongoDB/Repositories/ProductRepository.cs
+++ b/Mimir.MongoDB/Repositories/ProductRepository.cs
@@ -29,7 +29,7 @@ public class ProductRepository
 
     public async Task<ProductDocument> GetByProductIdAsync(Guid productId)
     {
-        var filter = Builders<ProductDocument>.Filter.Eq(doc => doc.Object.ProductId, productId);
+        var filter = Builders<ProductDocument>.Filter.Eq("Object.ProductId", productId);
         var productDocument = await _collection.Find(filter).FirstOrDefaultAsync();
         if (productDocument is null)
         {


### PR DESCRIPTION
- Resolve #454, #456
- See also https://github.com/planetarium/mimir/issues/402#issuecomment-2438247127

# Examples

## Case of product address 'ff6526b988ABDEEAA4D3Bf3e79cB681af4f929f5'

```graphql
query {
  product(productId: "f0994e0c-0295-493d-a395-951ca7152954") {
    ... on ItemProduct {
       tradableItem {
        id
        itemType
        itemSubType
        elementalType
       }
    }
  }
}
```
```json
{
  "data": {
    "product": {
      "tradableItem": {
        "id": 900109,
        "itemType": "CONSUMABLE",
        "itemSubType": "FOOD",
        "elementalType": "NORMAL"
      }
    }
  }
}
```

## Case of product address '925A08670723Ab5B16F3Ca133bbf2D73DF4a1237'

```graphql
query {
  product(productId: "adc9b9c8-ea71-4a56-9549-691f631a0b23") {
    ... on ItemProduct {
       tradableItem {
        id
        itemType
        itemSubType
        elementalType
       }
    }
  }
}
```
```json
{
  "data": {
    "product": {
      "tradableItem": {
        "id": 10354002,
        "itemType": "EQUIPMENT",
        "itemSubType": "BELT",
        "elementalType": "WIND"
      }
    }
  }
}
```