### PR TITLE
fix: correct the logic to fetch transactions

### DIFF
--- a/Mimir.Worker/Client/HeadlessGQLClient.cs
+++ b/Mimir.Worker/Client/HeadlessGQLClient.cs
@@ -94,7 +94,7 @@ public class HeadlessGQLClient : IHeadlessGQLClient
                         jsonResponse
                     );
 
-                    if (graphQLResponse is null || graphQLResponse.Data is null)
+                    if (graphQLResponse is null || graphQLResponse.Data is null || graphQLResponse.Errors is not null)
                     {
                         throw new HttpRequestException("Response data is null.");
                     }

--- a/Mimir.Worker/Client/Models.cs
+++ b/Mimir.Worker/Client/Models.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Mimir.Worker.Client;
@@ -14,7 +15,9 @@ public class GraphQLRequest
 public class GraphQLResponse<T>
 {
     [JsonPropertyName("data")]
-    public T Data { get; set; }
+    public T? Data { get; set; }
+
+    public JsonElement[]? Errors { get; set; }
 }
 
 public class GetAccountDiffsResponse

--- a/Mimir.Worker/Client/Models.cs
+++ b/Mimir.Worker/Client/Models.cs
@@ -62,13 +62,13 @@ public class GetStateResponse
 public class GetTransactionsResponse
 {
     [JsonPropertyName("transaction")]
-    public TransactionResponse Transaction { get; set; }
+    public TransactionResponse? Transaction { get; set; }
 }
 
 public class TransactionResponse
 {
     [JsonPropertyName("ncTransactions")]
-    public List<NcTransaction?> NCTransactions { get; set; }
+    public List<NcTransaction?>? NCTransactions { get; set; }
 }
 
 public class NcTransaction


### PR DESCRIPTION
This pull request fixes the logic to fetch transactions. To do it, I made some changes:

 - Validate `GetTransactionsResponse` manually. It validates responses like below:
    ```json
    {
		"data": {
			"transaction": null
		},
		...
	}
    ```
    ```json
    {
		"data": {
			"transaction": {
				"ncTransactions": null
			}
		},
		...
	}
    ```
    ```json
    {
		"data": {
			"transaction": {
				"ncTransactions": [
					{
						...,
						"actions": [
							null
						],
						...
					}
				]
			}
		},
		...
	}
    ```
 - Checks `"errors"` field is not `null` because there will be `errors` field when there were any errors while resolving the query, according to the GraphQL spec, https://spec.graphql.org/October2021/#sec-Errors.
 - Expire cached value after 30 seconds from writing. Though it tried to validate the responses, it can cache invalid response unfortunately. So it expire the cached value after 30 seconds from writing.