### PR TITLE
Sleep and continue when same target and base index

### DIFF
--- a/Mimir.Worker/StateDocumentConverter/AddressStatePair.cs
+++ b/Mimir.Worker/StateDocumentConverter/AddressStatePair.cs
@@ -5,7 +5,7 @@ namespace Mimir.Worker.StateDocumentConverter;
 
 public class AddressStatePair
 {
-    public int BlockIndex { get; set; }
+    public long BlockIndex { get; set; }
     public Address Address { get; set; }
     public IValue RawState { get; set; }
 }


### PR DESCRIPTION
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/3a93b633-257f-43fa-b6f6-53c446909461">

![image](https://github.com/user-attachments/assets/e37aa7df-68c3-4734-b6d4-87d0dc1484e6)

I added a missing `continue` statement to skip the request to `headless` when the indexes are the same.