### PR TITLE
chore: make easy to bump dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,3 +68,25 @@ Now, run Mimir with the environment variable pointing to the appsettings file yo
 ```sh
 ASPNETCORE_ENVIRONMENT=local dotnet run --project Mimir
 ```
+
+## Bump Lib9c
+
+Mimir is using [`Lib9c`][lib9c] to use their models. So you may need to bump `Lib9c` dependency to use new models in new release of it.
+
+Then you can update `<Lib9cVersion>` property in `Directory.Build.props`, with the `Lib9c` release version you want.
+
+## Bump Libplanet
+
+Mimir is using [`Libplanet`][libplanet] to use crypto-related types (e.g., `Address`), to iterate trie when initializing database from snapshots. So you may need to bump `Libplanet` and `Libplanet.*` dependencies to follow `Lib9c`'s `Libplanet` version.
+
+Then you can update `<LibplanetVersion>` property in `Directory.Build.props`, with the `Libplanet` release version you want.
+
+You can see the `Libplanet` version used by `Lib9c`, in NuGet's dependencies view.
+
+```
+# 'lib9c-version' may be like 1.20.0
+https://www.nuget.org/packages/Lib9c/<lib9c-version>#dependencies-body-tab
+```
+
+[lib9c]: https://github.com/planetarium/lib9c
+[libplanet]: https://github.com/planetarium/libplanet

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,8 @@
 <Project>
     <PropertyGroup>
         <NoWarn>NU1605</NoWarn>
+
+        <Lib9cVersion>1.19.0</Lib9cVersion>
+        <LibplanetVersion>5.4.0</LibplanetVersion>
     </PropertyGroup>
 </Project>

--- a/Lib9c.GraphQL/Lib9c.GraphQL.csproj
+++ b/Lib9c.GraphQL/Lib9c.GraphQL.csproj
@@ -14,8 +14,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Lib9c" Version="1.19.0" />
-        <PackageReference Include="Libplanet" Version="5.4.0" />
+        <PackageReference Include="Lib9c" Version="$(Lib9cVersion)" />
+        <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Lib9c.Models.Tests/Lib9c.Models.Tests.csproj
+++ b/Lib9c.Models.Tests/Lib9c.Models.Tests.csproj
@@ -12,8 +12,8 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Lib9c" Version="1.19.0" />
-        <PackageReference Include="Libplanet" Version="5.4.0" />
+        <PackageReference Include="Lib9c" Version="$(Lib9cVersion)" />
+        <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
         <PackageReference Include="xunit" Version="2.5.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>

--- a/Lib9c.Models/Lib9c.Models.csproj
+++ b/Lib9c.Models/Lib9c.Models.csproj
@@ -9,9 +9,9 @@
     
     <ItemGroup>
         <PackageReference Include="HotChocolate.AspNetCore" Version="14.1.0" />
-        <PackageReference Include="Lib9c" Version="1.19.0" />
-        <PackageReference Include="Libplanet" Version="5.4.0" />
         <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
+        <PackageReference Include="Lib9c" Version="$(Lib9cVersion)" />
+        <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
     </ItemGroup>
 
 </Project>

--- a/Mimir.MongoDB/Mimir.MongoDB.csproj
+++ b/Mimir.MongoDB/Mimir.MongoDB.csproj
@@ -9,11 +9,11 @@
 	<ItemGroup>
 		<PackageReference Include="HotChocolate.Abstractions" Version="14.1.0" />
 		<PackageReference Include="HotChocolate.Data.MongoDb" Version="14.1.0" />
-		<PackageReference Include="Lib9c" Version="1.19.0" />
-		<PackageReference Include="Libplanet" Version="5.4.0" />
 		<PackageReference Include="MongoDB.Bson" Version="3.0.0" />
 		<PackageReference Include="MongoDB.Driver" Version="3.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+		<PackageReference Include="Lib9c" Version="$(Lib9cVersion)"/>
+		<PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Mimir.Worker/Mimir.Worker.csproj
+++ b/Mimir.Worker/Mimir.Worker.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lib9c" Version="1.19.0" />
-    <PackageReference Include="Lib9c.Abstractions" Version="1.19.0" />
-    <PackageReference Include="Libplanet.RocksDBStore" Version="5.3.2-alpha.1" />
-    <PackageReference Include="Libplanet" Version="5.4.0" />
+    <PackageReference Include="Lib9c" Version="$(Lib9cVersion)" />
+    <PackageReference Include="Lib9c.Abstractions" Version="$(Lib9cVersion)" />
+    <PackageReference Include="Libplanet.RocksDBStore" Version="$(LibplanetVersion)" />
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Sentry" Version="4.12.1" />
     <PackageReference Include="Sentry.Serilog" Version="4.12.1" />

--- a/Mimir/Mimir.csproj
+++ b/Mimir/Mimir.csproj
@@ -19,8 +19,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Lib9c" Version="1.19.0" />
-    <PackageReference Include="Libplanet" Version="5.4.0" />
+    <PackageReference Include="Lib9c" Version="$(Lib9cVersion)" />
+    <PackageReference Include="Libplanet" Version="$(LibplanetVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.3.1" />
     <PackageReference Include="Sentry" Version="4.12.1" />


### PR DESCRIPTION
This pull request does:
 - Make `Libplanet`-related dependencies depend on `LibplanetVersion` property defined in `Directory.Build.props`
 - Make `Lib9c`-related dependencies depend on `Lib9cVersion` property defined in `Directory.Build.props`
 - Guide to update properties in `Directory.Build.props` when bumping dependencies.