### PR TITLE
update hot-chocolate to v14

### DIFF
--- a/Lib9c.GraphQL/Lib9c.GraphQL.csproj
+++ b/Lib9c.GraphQL/Lib9c.GraphQL.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.12" />
-        <PackageReference Include="HotChocolate.Types.Analyzers" Version="13.9.12">
+        <PackageReference Include="HotChocolate.AspNetCore" Version="14.1.0" />
+        <PackageReference Include="HotChocolate.Types.Analyzers" Version="14.1.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/Lib9c.Models/Lib9c.Models.csproj
+++ b/Lib9c.Models/Lib9c.Models.csproj
@@ -8,10 +8,10 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.12" />
+        <PackageReference Include="HotChocolate.AspNetCore" Version="14.1.0" />
         <PackageReference Include="Lib9c" Version="1.19.0" />
         <PackageReference Include="Libplanet" Version="5.4.0" />
-        <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
+        <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Lib9c.Models/Stats/DecimalStat.cs
+++ b/Lib9c.Models/Stats/DecimalStat.cs
@@ -6,6 +6,7 @@ using Lib9c.Models.Extensions;
 using MongoDB.Bson.Serialization.Attributes;
 using Nekoyume.Model.Stat;
 using ValueKind = Bencodex.Types.ValueKind;
+using KeyNotFoundException = System.Collections.Generic.KeyNotFoundException;
 
 namespace Lib9c.Models.Stats;
 

--- a/Mimir.MongoDB/Mimir.MongoDB.csproj
+++ b/Mimir.MongoDB/Mimir.MongoDB.csproj
@@ -7,15 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="HotChocolate.Abstractions" Version="13.9.12" />
-        <PackageReference Include="HotChocolate.Data.MongoDb" Version="13.9.12" />
-        <PackageReference Include="Lib9c" Version="1.19.0"/>
+        <PackageReference Include="HotChocolate.Abstractions" Version="14.1.0" />
+        <PackageReference Include="HotChocolate.Data.MongoDb" Version="14.1.0" />
+        <PackageReference Include="Lib9c" Version="1.19.0" />
         <PackageReference Include="Libplanet" Version="5.4.0" />
-        <PackageReference Include="MongoDB.Bson" Version="2.27.0" />
-        <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
-        <PackageReference Include="MongoDB.Driver.GridFS" Version="2.27.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-    </ItemGroup>
+        <PackageReference Include="MongoDB.Bson" Version="3.0.0" />
+        <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+	</ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Lib9c.GraphQL\Lib9c.GraphQL.csproj" />

--- a/Mimir.MongoDB/Mimir.MongoDB.csproj
+++ b/Mimir.MongoDB/Mimir.MongoDB.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="HotChocolate.Abstractions" Version="14.1.0" />
-        <PackageReference Include="HotChocolate.Data.MongoDb" Version="14.1.0" />
-        <PackageReference Include="Lib9c" Version="1.19.0" />
-        <PackageReference Include="Libplanet" Version="5.4.0" />
-        <PackageReference Include="MongoDB.Bson" Version="3.0.0" />
-        <PackageReference Include="MongoDB.Driver" Version="3.0.0" />
+	<ItemGroup>
+		<PackageReference Include="HotChocolate.Abstractions" Version="14.1.0" />
+		<PackageReference Include="HotChocolate.Data.MongoDb" Version="14.1.0" />
+		<PackageReference Include="Lib9c" Version="1.19.0" />
+		<PackageReference Include="Libplanet" Version="5.4.0" />
+		<PackageReference Include="MongoDB.Bson" Version="3.0.0" />
+		<PackageReference Include="MongoDB.Driver" Version="3.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
 	</ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\Lib9c.GraphQL\Lib9c.GraphQL.csproj" />
-        <ProjectReference Include="..\Lib9c.Models\Lib9c.Models.csproj"/>
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\Lib9c.GraphQL\Lib9c.GraphQL.csproj" />
+		<ProjectReference Include="..\Lib9c.Models\Lib9c.Models.csproj"/>
+	</ItemGroup>
 
 </Project>

--- a/Mimir.Tests/QueryTests/ActionPointTests.cs
+++ b/Mimir.Tests/QueryTests/ActionPointTests.cs
@@ -21,7 +21,7 @@ public class ActionPointTests
         const string query = "query { actionPoint(address: \"0x0000000000000000000000000000000000000000\") }";
         var result = await TestServices.ExecuteRequestAsync(
             serviceProvider,
-            b => b.SetQuery(query));
+            b => b.SetDocument(query));
 
         await Verify(result);
     }

--- a/Mimir.Tests/QueryTests/AgentTest.cs
+++ b/Mimir.Tests/QueryTests/AgentTest.cs
@@ -49,7 +49,7 @@ public class AgentTest
                         }
                       }
                       """;
-        var result = await TestServices.ExecuteRequestAsync(serviceProvider, b => b.SetQuery(query));
+        var result = await TestServices.ExecuteRequestAsync(serviceProvider, b => b.SetDocument(query));
 
         await Verify(result);
     }

--- a/Mimir.Tests/QueryTests/AvatarQueryTest.cs
+++ b/Mimir.Tests/QueryTests/AvatarQueryTest.cs
@@ -112,7 +112,7 @@ public class AvatarQueryTest
                           }
                       """;
 
-        var result = await TestServices.ExecuteRequestAsync(serviceProvider, b => b.SetQuery(query));
+        var result = await TestServices.ExecuteRequestAsync(serviceProvider, b => b.SetDocument(query));
 
         await Verify(result);
     }

--- a/Mimir.Tests/QueryTests/CombinationSlotsTest.cs
+++ b/Mimir.Tests/QueryTests/CombinationSlotsTest.cs
@@ -77,7 +77,7 @@ public class CombinationSlotsTest
                           }
                         }                 
                       """;
-        var result = TestServices.ExecuteRequestAsync(serviceProvider, b => b.SetQuery(query));
+        var result = TestServices.ExecuteRequestAsync(serviceProvider, b => b.SetDocument(query));
 
         await Verify(result);
     }

--- a/Mimir.Tests/QueryTests/DailyRewardQueryTest.cs
+++ b/Mimir.Tests/QueryTests/DailyRewardQueryTest.cs
@@ -25,7 +25,7 @@ public class DailyRewardQueryTest
                         dailyRewardReceivedBlockIndex(address: "{{mockAddress}}")
                       }
                       """;
-        var result = await TestServices.ExecuteRequestAsync(serviceProvider, b => b.SetQuery(query));
+        var result = await TestServices.ExecuteRequestAsync(serviceProvider, b => b.SetDocument(query));
 
         await Verify(result);
     }

--- a/Mimir.Tests/TestServices.cs
+++ b/Mimir.Tests/TestServices.cs
@@ -57,21 +57,21 @@ public static class TestServices
 
     public static async Task<string> ExecuteRequestAsync(
         IServiceProvider serviceProvider,
-        Action<IQueryRequestBuilder> configureRequest,
+        Action<OperationRequestBuilder> configureRequest,
         CancellationToken cancellationToken = default)
     {
         await using var scope = serviceProvider.CreateAsyncScope();
 
-        var requestBuilder = new QueryRequestBuilder();
+        var requestBuilder = new OperationRequestBuilder();
         requestBuilder.SetServices(scope.ServiceProvider);
         configureRequest(requestBuilder);
-        var request = requestBuilder.Create();
+        var request = requestBuilder.Build();
 
         var executor = await scope.ServiceProvider
             .GetRequiredService<IRequestExecutorResolver>()
             .GetRequestExecutorAsync(cancellationToken: cancellationToken);
         await using var result = await executor.ExecuteAsync(request, cancellationToken);
-        result.ExpectQueryResult();
+        result.ExpectOperationResult();
         return result.ToJson();
     }
 }

--- a/Mimir/GraphQL/HttpResponseFormatter.cs
+++ b/Mimir/GraphQL/HttpResponseFormatter.cs
@@ -7,7 +7,7 @@ namespace Mimir.GraphQL;
 public class HttpResponseFormatter : DefaultHttpResponseFormatter
 {
     protected override HttpStatusCode OnDetermineStatusCode(
-        IQueryResult result,
+        IOperationResult result,
         FormatInfo format,
         HttpStatusCode? proposedStatusCode)
     {

--- a/Mimir/Mimir.csproj
+++ b/Mimir/Mimir.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.12" />
-    <PackageReference Include="HotChocolate.Types.Analyzers" Version="13.9.12">
+    <PackageReference Include="HotChocolate.AspNetCore" Version="14.1.0" />
+    <PackageReference Include="HotChocolate.Types.Analyzers" Version="14.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
resolves #498 

- Hot Chocolate: Updated to version 14.1.0
- MongoDB Libraries: Upgraded to version 3.0.0
- Removed MongoDB.Driver.GridFS as GridFS support is now included in MongoDB.Driver v3.0.0
- Code Refactor: Adjusted implementations to align with breaking changes and new features introduced in Hot Chocolate 14.1.0.