### PR TITLE
Bump lib9c 1.36.1 and handle event_dungeon_battle_sweep

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
-    <PropertyGroup>
-        <Lib9cVersion>1.32.0</Lib9cVersion>
-        <LibplanetVersion>5.5.2</LibplanetVersion>
-    </PropertyGroup>
+  <PropertyGroup>
+    <Lib9cVersion>1.36.1</Lib9cVersion>
+    <LibplanetVersion>5.5.2</LibplanetVersion>
+  </PropertyGroup>
 </Project>

--- a/Mimir.Worker/ActionHandler/ItemSlotStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/ItemSlotStateHandler.cs
@@ -30,7 +30,7 @@ public class ItemSlotStateHandler(
         store,
         headlessGqlClient,
         initializerManager,
-        "^hack_and_slash[0-9]*$|^hack_and_slash_sweep[0-9]*$|^battle_arena[0-9]*$|^event_dungeon_battle[0-9]*$|^join_arena[0-9]*$|^raid[0-9]*$",
+        "^hack_and_slash[0-9]*$|^hack_and_slash_sweep[0-9]*$|^battle_arena[0-9]*$|^event_dungeon_battle[0-9]*$|^event_dungeon_battle_sweep[0-9]*$|^join_arena[0-9]*$|^raid[0-9]*$",
         Log.ForContext<ItemSlotStateHandler>(),
         stateGetterService
     )
@@ -87,6 +87,19 @@ public class ItemSlotStateHandler(
         if (Regex.IsMatch(actionType, "^event_dungeon_battle[0-9]*$"))
         {
             var action = new EventDungeonBattle();
+            action.LoadPlainValue(actionPlainValue);
+            return await ItemSlotCollectionUpdater.UpdateAsync(
+                StateService,
+                blockIndex,
+                BattleType.Adventure,
+                action.AvatarAddress,
+                stoppingToken
+            );
+        }
+
+        if (Regex.IsMatch(actionType, "^event_dungeon_battle_sweep[0-9]*$"))
+        {
+            var action = new EventDungeonBattleSweep();
             action.LoadPlainValue(actionPlainValue);
             return await ItemSlotCollectionUpdater.UpdateAsync(
                 StateService,

--- a/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
+++ b/Mimir.Worker/ActionHandler/RuneSlotStateHandler.cs
@@ -30,7 +30,7 @@ public class RuneSlotStateHandler(
         store,
         headlessGqlClient,
         initializerManager,
-        "^(battle_arena[0-9]*|event_dungeon_battle[0-9]*|hack_and_slash[0-9]*|hack_and_slash_sweep[0-9]*|join_arena[0-9]*|raid[0-9]*|unlock_rune_slot[0-9]*)$",
+        "^(battle_arena[0-9]*|event_dungeon_battle[0-9]*|event_dungeon_battle_sweep[0-9]*|hack_and_slash[0-9]*|hack_and_slash_sweep[0-9]*|join_arena[0-9]*|raid[0-9]*|unlock_rune_slot[0-9]*)$",
         Log.ForContext<RuneSlotStateHandler>(),
         stateGetterService
     )
@@ -86,6 +86,13 @@ public class RuneSlotStateHandler(
             return await TryProcessRuneSlotStateAsync(blockIndex, action, stoppingToken);
         }
 
+        if (Regex.IsMatch(actionType, "^event_dungeon_battle_sweep[0-9]*$"))
+        {
+            var action = new EventDungeonBattleSweep();
+            action.LoadPlainValue(actionPlainValue);
+            return await TryProcessRuneSlotStateAsync(blockIndex, action, stoppingToken);
+        }
+
         if (Regex.IsMatch(actionType, "^hack_and_slash[0-9]*$"))
         {
             var action = new HackAndSlash();
@@ -135,6 +142,21 @@ public class RuneSlotStateHandler(
     private async Task<IEnumerable<WriteModel<BsonDocument>>> TryProcessRuneSlotStateAsync(
         long blockIndex,
         EventDungeonBattle action,
+        CancellationToken stoppingToken = default
+    )
+    {
+        return await RuneSlotCollectionUpdater.UpdateAsync(
+            blockIndex,
+            StateService,
+            BattleType.Adventure,
+            action.AvatarAddress,
+            stoppingToken
+        );
+    }
+
+    private async Task<IEnumerable<WriteModel<BsonDocument>>> TryProcessRuneSlotStateAsync(
+        long blockIndex,
+        EventDungeonBattleSweep action,
         CancellationToken stoppingToken = default
     )
     {

--- a/Mimir.Worker/Util/ActionParser.cs
+++ b/Mimir.Worker/Util/ActionParser.cs
@@ -469,6 +469,9 @@ public static class ActionParser
                 case IEventDungeonBattleV2 eventDungeonBattle2:
                     avatarAddress = eventDungeonBattle2.AvatarAddress;
                     break;
+                case IEventDungeonBattleSweep eventDungeonBattleSweep:
+                    avatarAddress = eventDungeonBattleSweep.AvatarAddress;
+                    break;
                 case IEventMaterialItemCraftsV1 eventMaterialItemCrafts:
                     avatarAddress = eventMaterialItemCrafts.AvatarAddress;
                     break;


### PR DESCRIPTION
## Summary
- Bumps `Lib9cVersion` to `1.36.1` in `Directory.Build.props`.
- Handles the newly introduced `event_dungeon_battle_sweep` action in `ItemSlotStateHandler` and `RuneSlotStateHandler` (Adventure slot states get refreshed when a sweep is executed).
- Adds the `IEventDungeonBattleSweep` case to `ActionParser` so `BlockHandler` extracts the avatar address for transaction indexing.

Note: the other new action in 1.36.1, `grant_items`, implements `IClaimItems`, so `ActionParser` already routes it through the existing `IClaimItems` branch and its state effects flow through the diff poller — no extra wiring needed.

## Test plan
- [x] `dotnet build Mimir.sln -c Release` succeeds.
- [x] `dotnet test Mimir.sln -c Release` — 169 passed, 2 skipped, 0 failed.
- [ ] Smoke test on a network that has `event_dungeon_battle_sweep` traffic: confirm `ItemSlot`/`RuneSlot` documents are updated for Adventure battle type after a sweep tx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)